### PR TITLE
use template in atomic dsl instead proc avoid atomic copy

### DIFF
--- a/src/lockfreequeues/atomic_dsl.nim
+++ b/src/lockfreequeues/atomic_dsl.nim
@@ -9,31 +9,31 @@
 import atomics
 
 
-proc relaxed*[T](location: var Atomic[T]): T {.inline.} =
+template relaxed*[T](location: var Atomic[T]): T =
   ## Load the value from location using moRelaxed
-  result = location.load(moRelaxed)
+  location.load(moRelaxed)
 
 
-proc acquire*[T](location: var Atomic[T]): T {.inline.} =
+template acquire*[T](location: var Atomic[T]): T =
   ## Load the value from location using moAcquire
-  result = location.load(moAcquire)
+  location.load(moAcquire)
 
 
-proc sequential*[T](location: var Atomic[T]): T {.inline.} =
+template sequential*[T](location: var Atomic[T]): T =
   ## Load the value from location using moSequentiallyConsistent
-  result = location.load(moSequentiallyConsistent)
+  location.load(moSequentiallyConsistent)
 
 
-proc relaxed*[T](location: var Atomic[T], value: T) {.inline.} =
+template relaxed*[T](location: var Atomic[T], value: T) =
   ## Store the value in location using moRelaxed
   location.store(value, moRelaxed)
 
 
-proc release*[T](location: var Atomic[T], value: T) {.inline.} =
+template release*[T](location: var Atomic[T], value: T) =
   ## Store the value in location using moRelease
   location.store(value, moRelease)
 
 
-proc sequential*[T](location: var Atomic[T], value: T) {.inline.} =
+template sequential*[T](location: var Atomic[T], value: T) =
   ## Store the value in location using moSequentiallyConsistent
   location.store(value, moSequentiallyConsistent)


### PR DESCRIPTION
the compiler will create a temporary variable and assign atomic argument to it , however the cpp copy constructor for atomic is `deleted`.

see changes in my PR https://github.com/nim-lang/Nim/pull/21169

when this merged, please also bump new version as this is important package in Nim CI