### PR TITLE
`full()` returns `false` false-negatively when buffer wraps around

### DIFF
--- a/lockfreequeues.nimble
+++ b/lockfreequeues.nimble
@@ -1,7 +1,7 @@
 import os
 
 # Package
-version       = "3.0.0"
+version       = "3.0.1"
 author        = "Elijah Shaw-Rutschman"
 description   = "Lock-free queue implementations for Nim."
 license       = "MIT"

--- a/src/lockfreequeues/ops.nim
+++ b/src/lockfreequeues/ops.nim
@@ -87,7 +87,7 @@ proc full*(
   ## Determine if storage is full given `head`, `tail`, and `capacity` values.
   validateHeadOrTail(head, capacity)
   validateHeadOrTail(tail, capacity)
-  return abs(tail - head) >= capacity
+  return used(head, tail, capacity) >= capacity
 
 
 proc empty*(
@@ -100,4 +100,3 @@ proc empty*(
   validateHeadOrTail(head, capacity)
   validateHeadOrTail(tail, capacity)
   return head == tail
-


### PR DESCRIPTION
When the buffer wraps around but slots at the beginning of the ring where popped already, `full()` false-negatively returns `false`. As a result `push()` etc. might return `false` false-negatively as well.

Reason seems to be that `abs(tail - head) >= capacity` does not work for the case where the buffer wraps around. This PR attempts to fix this by using `used()`: `full = used(head, tail, capacity) == capacity`.

Thanks for this nice package! :)