### PR TITLE
feat: cloud bench harness with Bencher.dev gating

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -86,7 +86,13 @@ jobs:
             benchmarks/nim/bench_throughput.nim
 
       - name: Run bench_throughput
-        run: ./.tmp/bench_throughput | tee bench_output.txt
+        # Mupmuc 4P/4C is skipped on shared CI runners: 8 threads on a
+        # 4-vCPU runner with a small-capacity bounded MPMC livelocks under
+        # scheduler pressure and hangs the job to the 30-min timeout.
+        # Tracked in https://github.com/elijahr/lockfreequeues/issues/15.
+        # Other variants (sipsic, unbounded_mupsic, channels) complete in
+        # single-digit minutes and exercise the harness end-to-end.
+        run: ./.tmp/bench_throughput sipsic unbounded_mupsic channels | tee bench_output.txt
 
       - name: Convert to BMF JSON
         run: python3 benchmarks/bmf_adapter.py bench_output.txt bench_results.json

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,7 +5,12 @@ name: bench
 # yamllint disable rule:truthy
 on:
   pull_request:
-    branches: [main, devel]
+    branches:
+      - main
+      - devel
+      - 'feat/**'
+      - 'perf/**'
+      - 'fix/**'
     paths-ignore:
       - '*.md'
       - '.github/workflows/docs.yml'

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -74,15 +74,19 @@ jobs:
 
       - name: Compile bench_throughput (CI-tuned run shape)
         # Cloud runs use a tighter wall-clock budget than the local default
-        # (1M messages × 33 runs). 100k × 5 keeps the harness honest while
-        # finishing in single-digit minutes; warmup stays at 2 to absorb
-        # JIT/cache effects. UnboundedMupsicRuns mirrors DefaultRuns.
+        # (1M messages × 33 runs). Bounded variants (sipsic, channels) use
+        # 100k × 5 runs and finish in single-digit seconds. unbounded_mupsic
+        # is super-linear in message count and is gated separately via
+        # UnboundedMupsicMessageCount=5000 + UnboundedMupsicRuns=3 to keep
+        # the variant tractable inside the 30-min job budget. Warmup stays
+        # at 2 to absorb JIT/cache effects.
         run: |
           nim c -d:release -d:danger --threads:on \
             -d:MessageCount=100000 \
             -d:DefaultRuns=5 \
             -d:WarmupRuns=2 \
-            -d:UnboundedMupsicRuns=5 \
+            -d:UnboundedMupsicRuns=3 \
+            -d:UnboundedMupsicMessageCount=5000 \
             benchmarks/nim/bench_throughput.nim
 
       - name: Run bench_throughput
@@ -92,6 +96,10 @@ jobs:
         # Tracked in https://github.com/elijahr/lockfreequeues/issues/15.
         # Other variants (sipsic, unbounded_mupsic, channels) complete in
         # single-digit minutes and exercise the harness end-to-end.
+        # Step-level timeout: if any single variant hangs, fail fast inside
+        # the 30-min job budget so Bencher upload steps still run (or are
+        # visibly skipped) instead of burning the entire budget on one variant.
+        timeout-minutes: 20
         run: ./.tmp/bench_throughput sipsic unbounded_mupsic channels | tee bench_output.txt
 
       - name: Convert to BMF JSON

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -79,29 +79,28 @@ jobs:
       - name: Compile bench_throughput (CI-tuned run shape)
         # Cloud runs use a tighter wall-clock budget than the local default
         # (1M messages × 33 runs). Bounded variants (sipsic, channels) use
-        # 100k × 5 runs and finish in single-digit seconds. unbounded_mupsic
+        # 1M × 5 runs and finish in single-digit seconds. unbounded_mupsic
         # is super-linear in message count and is gated separately via
-        # UnboundedMupsicMessageCount=50000 + UnboundedMupsicRuns=3 to keep
+        # UnboundedMupsicMessageCount=500000 + UnboundedMupsicRuns=3 to keep
         # the variant tractable inside the 30-min job budget. Warmup stays
         # at 2 to absorb JIT/cache effects.
         #
-        # Why 50000 (not 5000): bench_throughput.nim uses a millisecond-
-        # precision timer. At N=5000 the unbounded_mupsic variant finishes
-        # in well under 1 ms per run, so ops/ms is reported as `inf`, the
-        # BMF adapter discards the data points, and Bencher receives nothing
-        # for the variant we actually want to gate on. Local smoke at N=50000
-        # finishes in ~0.26s with stable per-topology numbers (1P/1C ~9.4k
-        # ops/ms, 2P/1C ~10.8k, 4P/1C ~8.9k). 50K × 3 runs × 3 topologies
-        # plus warmup costs roughly 4-10s on CI: well inside the 30-min job
-        # budget while giving the timer enough wall-clock to produce a
-        # stable signal.
+        # Counts are 10x the previous values (100k / 50k → 1M / 500k) and
+        # the bench timer is microsecond/nanosecond-precision (computed in
+        # ns, printed as `mean: <N>.1f ops/ms`). Together this gives non-zero
+        # stddev and >1-decimal resolution between runs on the fast CI
+        # runner; previously a 50k unbounded_mupsic run completed in ~3 ms,
+        # so multiple samples bucketed into the same integer ms and stddev
+        # was reported as 0. The new shape costs roughly 30-60s on CI: well
+        # inside the 30-min job budget while giving the timer enough
+        # wall-clock spread to produce a stable, comparable signal.
         run: |
           nim c -d:release -d:danger --threads:on \
-            -d:MessageCount=100000 \
+            -d:MessageCount=1000000 \
             -d:DefaultRuns=5 \
             -d:WarmupRuns=2 \
             -d:UnboundedMupsicRuns=3 \
-            -d:UnboundedMupsicMessageCount=50000 \
+            -d:UnboundedMupsicMessageCount=500000 \
             benchmarks/nim/bench_throughput.nim
 
       - name: Run bench_throughput

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,6 +19,10 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Exposed at job env so step-level `if:` expressions can gate on
+  # presence via `env.BENCHER_API_TOKEN`. GitHub Actions does not allow
+  # `secrets.*` directly in `if:`, so the env-var indirection is required.
+  BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
 
 jobs:
   benchmark:
@@ -77,16 +81,27 @@ jobs:
         # (1M messages × 33 runs). Bounded variants (sipsic, channels) use
         # 100k × 5 runs and finish in single-digit seconds. unbounded_mupsic
         # is super-linear in message count and is gated separately via
-        # UnboundedMupsicMessageCount=5000 + UnboundedMupsicRuns=3 to keep
+        # UnboundedMupsicMessageCount=50000 + UnboundedMupsicRuns=3 to keep
         # the variant tractable inside the 30-min job budget. Warmup stays
         # at 2 to absorb JIT/cache effects.
+        #
+        # Why 50000 (not 5000): bench_throughput.nim uses a millisecond-
+        # precision timer. At N=5000 the unbounded_mupsic variant finishes
+        # in well under 1 ms per run, so ops/ms is reported as `inf`, the
+        # BMF adapter discards the data points, and Bencher receives nothing
+        # for the variant we actually want to gate on. Local smoke at N=50000
+        # finishes in ~0.26s with stable per-topology numbers (1P/1C ~9.4k
+        # ops/ms, 2P/1C ~10.8k, 4P/1C ~8.9k). 50K × 3 runs × 3 topologies
+        # plus warmup costs roughly 4-10s on CI: well inside the 30-min job
+        # budget while giving the timer enough wall-clock to produce a
+        # stable signal.
         run: |
           nim c -d:release -d:danger --threads:on \
             -d:MessageCount=100000 \
             -d:DefaultRuns=5 \
             -d:WarmupRuns=2 \
             -d:UnboundedMupsicRuns=3 \
-            -d:UnboundedMupsicMessageCount=5000 \
+            -d:UnboundedMupsicMessageCount=50000 \
             benchmarks/nim/bench_throughput.nim
 
       - name: Run bench_throughput
@@ -111,9 +126,21 @@ jobs:
       - name: Install Bencher CLI
         uses: bencherdev/bencher@main
 
+      - name: Bencher token preflight
+        # Always runs. Surfaces a yellow PR-check warning when the upload
+        # secret is unset so it is obvious from the check summary why the
+        # downstream Bencher steps were skipped, rather than the bench
+        # silently appearing to "do nothing" with the data.
+        run: |
+          if [ -z "$BENCHER_API_TOKEN" ]; then
+            echo "::warning title=Bencher upload skipped::BENCHER_API_TOKEN secret is not set on this repo. The bench ran successfully and produced bench_results.json (visible in the 'Show BMF JSON (debug)' step), but no data is being uploaded to Bencher.dev. Set up the project at bencher.dev with slug 'lockfreequeues' and add BENCHER_API_TOKEN as a repo secret to enable upload."
+          else
+            echo "Bencher token present; proceeding with upload."
+          fi
+
       # PR runs: compare against base branch and post a comment.
       - name: Track PR benchmarks with Bencher
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.BENCHER_API_TOKEN != ''
         run: |
           bencher run \
             --project lockfreequeues \
@@ -131,7 +158,7 @@ jobs:
 
       # Push to main/devel: record the baseline for that branch.
       - name: Track base branch benchmarks with Bencher
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && env.BENCHER_API_TOKEN != ''
         run: |
           bencher run \
             --project lockfreequeues \
@@ -150,7 +177,7 @@ jobs:
 
       # workflow_dispatch: just upload, no comparison.
       - name: Track manual benchmarks with Bencher
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && env.BENCHER_API_TOKEN != ''
         run: |
           bencher run \
             --project lockfreequeues \

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,147 @@
+# yamllint disable rule:line-length
+
+name: bench
+
+# yamllint disable rule:truthy
+on:
+  pull_request:
+    branches: [main, devel]
+    paths-ignore:
+      - '*.md'
+      - '.github/workflows/docs.yml'
+  push:
+    branches: [main, devel]
+    paths-ignore:
+      - '*.md'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+# yamllint enable rule:truthy
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  benchmark:
+    name: Throughput bench (ubuntu-latest)
+    runs-on: ubuntu-latest
+    # PRs from forks cannot read BENCHER_API_TOKEN. Skip rather than fail
+    # noisily; maintainer pushes / merges still record the baseline.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
+      checks: write
+    timeout-minutes: 30
+
+    steps:
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: ${HOME}/.cache
+          key: cache-bench-${{ runner.os }}
+
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Setup Nim
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: 'stable'
+
+      - name: Install build deps (Linux)
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get -qq install -y clang
+
+      - name: Clone and install sibling Nim deps (nim-debra, nim-typestates)
+        # Mirrors build.yml: nim.cfg uses --path:"../nim-debra/src" and
+        # --path:"../nim-typestates/src", and nimble's resolver runs before
+        # the compiler so we must install matching branches locally.
+        run: |
+          set -e
+          cd ..
+          git clone --depth 1 --branch main https://github.com/elijahr/nim-debra.git
+          git clone --depth 1 --branch main https://github.com/elijahr/nim-typestates.git
+          (cd nim-typestates && nimble install -y)
+          (cd nim-debra && nimble install -y)
+
+      - name: Vendor unittest2
+        run: git clone --depth 1 https://github.com/status-im/nim-unittest2.git deps/unittest2
+
+      - name: Run adapter unit tests
+        # Cheap pre-flight: fail fast if the parser itself is broken before
+        # spending minutes compiling and running the bench binary.
+        run: python3 benchmarks/test_bmf_adapter.py -v
+
+      - name: Compile bench_throughput (CI-tuned run shape)
+        # Cloud runs use a tighter wall-clock budget than the local default
+        # (1M messages × 33 runs). 100k × 5 keeps the harness honest while
+        # finishing in single-digit minutes; warmup stays at 2 to absorb
+        # JIT/cache effects. UnboundedMupsicRuns mirrors DefaultRuns.
+        run: |
+          nim c -d:release -d:danger --threads:on \
+            -d:MessageCount=100000 \
+            -d:DefaultRuns=5 \
+            -d:WarmupRuns=2 \
+            -d:UnboundedMupsicRuns=5 \
+            benchmarks/nim/bench_throughput.nim
+
+      - name: Run bench_throughput
+        run: ./.tmp/bench_throughput | tee bench_output.txt
+
+      - name: Convert to BMF JSON
+        run: python3 benchmarks/bmf_adapter.py bench_output.txt bench_results.json
+
+      - name: Show BMF JSON (debug)
+        run: cat bench_results.json
+
+      - name: Install Bencher CLI
+        uses: bencherdev/bencher@main
+
+      # PR runs: compare against base branch and post a comment.
+      - name: Track PR benchmarks with Bencher
+        if: github.event_name == 'pull_request'
+        run: |
+          bencher run \
+            --project lockfreequeues \
+            --token '${{ secrets.BENCHER_API_TOKEN }}' \
+            --branch "$GITHUB_HEAD_REF" \
+            --start-point "$GITHUB_BASE_REF" \
+            --start-point-hash '${{ github.event.pull_request.base.sha }}' \
+            --start-point-clone-thresholds \
+            --start-point-reset \
+            --testbed ubuntu-latest \
+            --adapter json \
+            --file bench_results.json \
+            --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+            --err
+
+      # Push to main/devel: record the baseline for that branch.
+      - name: Track base branch benchmarks with Bencher
+        if: github.event_name == 'push'
+        run: |
+          bencher run \
+            --project lockfreequeues \
+            --token '${{ secrets.BENCHER_API_TOKEN }}' \
+            --branch "${GITHUB_REF##*/}" \
+            --testbed ubuntu-latest \
+            --threshold-measure throughput \
+            --threshold-test t_test \
+            --threshold-max-sample-size 64 \
+            --threshold-lower-boundary 0.99 \
+            --thresholds-reset \
+            --adapter json \
+            --file bench_results.json \
+            --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+            --err
+
+      # workflow_dispatch: just upload, no comparison.
+      - name: Track manual benchmarks with Bencher
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          bencher run \
+            --project lockfreequeues \
+            --token '${{ secrets.BENCHER_API_TOKEN }}' \
+            --branch "${GITHUB_REF##*/}" \
+            --testbed ubuntu-latest \
+            --adapter json \
+            --file bench_results.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Throughput bench harness for `UnboundedMupsic` (1P/1C, 2P/1C, 4P/1C) at `benchmarks/nim/bench_throughput.nim` plus a thin adapter at `benchmarks/nim/adapters/lockfreequeues_unbounded_mupsic.nim` that owns the queue and `DebraManager`. Producer threads register their own `ThreadHandle` in-thread (handles are per-thread by construction). The new variants run for 33 timed iterations + 3 warmup; existing Sipsic/Mupmuc/Channels run counts are unchanged.
 - `bench_throughput` accepts variant-group args (`sipsic`, `mupmuc`, `unbounded_mupsic`, `channels`) to limit which benchmarks run. With no args, all variants run (backward compatible). Multiple args take the union of groups. Unknown args print the supported list and exit non-zero. Lets gate runs target a single queue family without paying for the slow bounded MPMC variants.
+- Compile-time overrides for `bench_throughput` run shape via `{.intdefine.}` constants: `-d:MessageCount=N`, `-d:DefaultRuns=N`, `-d:WarmupRuns=N`, `-d:UnboundedMupsicRuns=N`, `-d:UnboundedMupsicSegmentSize=N`, `-d:UnboundedMupsicMaxThreads=N`. Defaults are unchanged (1M messages, 33 runs, 3 warmup). Lets gate runs trade statistical confidence for wall-clock budget without source edits. `bench_throughput` also unbuffers stdout in `isMainModule` so progress is visible under file redirect.
 
 ## [3.2.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Throughput bench harness for `UnboundedMupsic` (1P/1C, 2P/1C, 4P/1C) at `benchmarks/nim/bench_throughput.nim` plus a thin adapter at `benchmarks/nim/adapters/lockfreequeues_unbounded_mupsic.nim` that owns the queue and `DebraManager`. Producer threads register their own `ThreadHandle` in-thread (handles are per-thread by construction). The new variants run for 33 timed iterations + 3 warmup; existing Sipsic/Mupmuc/Channels run counts are unchanged.
+
 ## [3.2.0] - 2026-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Throughput bench harness for `UnboundedMupsic` (1P/1C, 2P/1C, 4P/1C) at `benchmarks/nim/bench_throughput.nim` plus a thin adapter at `benchmarks/nim/adapters/lockfreequeues_unbounded_mupsic.nim` that owns the queue and `DebraManager`. Producer threads register their own `ThreadHandle` in-thread (handles are per-thread by construction). The new variants run for 33 timed iterations + 3 warmup; existing Sipsic/Mupmuc/Channels run counts are unchanged.
+- `bench_throughput` accepts variant-group args (`sipsic`, `mupmuc`, `unbounded_mupsic`, `channels`) to limit which benchmarks run. With no args, all variants run (backward compatible). Multiple args take the union of groups. Unknown args print the supported list and exit non-zero. Lets gate runs target a single queue family without paying for the slow bounded MPMC variants.
 
 ## [3.2.0] - 2026-04-27
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,24 +1,98 @@
 # Benchmark Suite
 
-Comprehensive benchmark suite for lockfreequeues.
+Throughput and latency benchmarks for lockfreequeues, plus a cloud-based
+regression gate via [Bencher.dev](https://bencher.dev).
 
 ## Structure
 
 - `nim/` - Nim benchmarks (lockfreequeues, Loony, Nim channels)
-- `results/` - JSON output from benchmark runs
-- `runner.py` - Orchestrates benchmark execution
+- `results/` - JSON output from local benchmark runs
+- `runner.py` - Orchestrates local benchmark execution
+- `bmf_adapter.py` - Converts `bench_throughput` stdout to Bencher Metric Format
+- `test_bmf_adapter.py` - Unit tests for the BMF adapter
 
-## Quick Start
+## Quick Start (local)
 
 ```bash
-# Run all Nim benchmarks
-python benchmarks/runner.py run --language nim
+# Run all Nim throughput benchmarks (1M messages × 33 runs - takes a while).
+nim c -r -d:release -d:danger --threads:on benchmarks/nim/bench_throughput.nim
 
-# Run specific benchmark
-nim c -r -d:release --threads:on benchmarks/nim/bench_throughput.nim
+# Same, but the CI wall-clock budget (100k × 5).
+nim c -r -d:release -d:danger --threads:on \
+  -d:MessageCount=100000 -d:DefaultRuns=5 -d:WarmupRuns=2 \
+  -d:UnboundedMupsicRuns=5 \
+  benchmarks/nim/bench_throughput.nim
+
+# Convert the captured stdout to BMF JSON for upload / inspection.
+./.tmp/bench_throughput > bench_output.txt
+python3 benchmarks/bmf_adapter.py bench_output.txt bench_results.json
 ```
 
 ## Metrics
 
-- **Throughput**: ops/ms with N producer/consumer threads
-- **Latency**: RTT nanoseconds with percentiles (p50, p95, p99, p999)
+- **Throughput**: `ops/ms` with N producer / N consumer threads
+  (mean, optional min/max for unbounded variants).
+- **Latency**: RTT nanoseconds with percentiles (p50, p95, p99, p999).
+
+## Cloud benchmarking (Bencher.dev)
+
+`.github/workflows/bench.yml` runs `bench_throughput` on `ubuntu-latest`
+for every PR and every push to `main`/`devel`. The workflow:
+
+1. Compiles `bench_throughput` with the CI run shape
+   (`-d:MessageCount=100000 -d:DefaultRuns=5 -d:WarmupRuns=2
+   -d:UnboundedMupsicRuns=5`).
+2. Captures stdout to `bench_output.txt`.
+3. Runs `bmf_adapter.py` to emit `bench_results.json` in
+   [Bencher Metric Format](https://bencher.dev/docs/reference/bencher-metric-format/).
+4. Uploads the JSON to the `lockfreequeues` Bencher project via the
+   `bencherdev/bencher@main` action.
+
+On pull requests, Bencher posts a comparison comment against the base
+branch using `--start-point-clone-thresholds` and `--start-point-reset`,
+so threshold breaches show up inline.
+
+The workflow also runs on `workflow_dispatch` for ad-hoc baseline pinning.
+
+### One-time setup (maintainer)
+
+The cloud workflow requires:
+
+1. A Bencher.dev project named `lockfreequeues`
+   (create at https://bencher.dev with that exact slug).
+2. A repository secret `BENCHER_API_TOKEN` containing a Bencher API token
+   with write access to the project.
+
+Until those exist the `bench` workflow will fail on the upload step;
+PR / push events still produce the `bench_results.json` artifact in the
+job log so local debugging is possible without the upload.
+
+### BMF schema emitted
+
+```json
+{
+  "<variant>/<P>p<C>c": {
+    "throughput": {
+      "value": <mean ops/ms>,
+      "lower_value": <min ops/ms, optional>,
+      "upper_value": <max ops/ms, optional>
+    }
+  }
+}
+```
+
+`<variant>` is one of `sipsic`, `mupmuc`, `unbounded_mupsic`, `channels`.
+`lower_value` / `upper_value` are populated only for blocks that print a
+`min: ... max: ...` line (currently only the `unbounded_mupsic` group).
+Non-finite samples (`inf`, `nan`) are dropped with a stderr warning so
+spurious cold-cache outliers do not poison the upload.
+
+## Running adapter tests
+
+```bash
+python3 benchmarks/test_bmf_adapter.py -v
+```
+
+The tests use only the Python standard library (`unittest`) and run in
+< 0.1s. They cover full and partial bench output, unknown variants, and
+the CLI's exit codes.

--- a/benchmarks/bmf_adapter.py
+++ b/benchmarks/bmf_adapter.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Convert bench_throughput.nim stdout to Bencher Metric Format (BMF) JSON.
+
+The Nim throughput bench prints variant blocks in this shape:
+
+    Sipsic (bounded SPSC) 1P/1C:
+      mean: 11232. ops/ms
+      stddev: 3268.
+
+    Mupmuc (bounded MPMC) 2P/2C:
+      mean: 8000. ops/ms
+      stddev: 2582.
+
+    UnboundedMupsic (unbounded MPSC) 4P/1C:
+      mean: 7500. ops/ms
+      min: 5000.  max: 10000.
+      stddev: 3536.
+
+    Channels (MPMC) 4P/4C:
+      mean: 645. ops/ms
+      stddev: 327.
+
+We map each block to a BMF entry keyed by `<variant>/<P>p<C>c`, exposing the
+mean as the throughput `value`. When the bench emits min/max (currently only
+the unbounded_mupsic group), they populate `lower_value` and `upper_value`.
+
+Non-finite samples (`inf`, `nan`) are dropped — Bencher rejects non-finite
+floats. If a block has only non-finite samples, the block is skipped with a
+warning, so the rest of the run still reports.
+
+Usage:
+    python benchmarks/bmf_adapter.py <input.txt> <output.json>
+
+If `<output.json>` is `-`, JSON is written to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# Maps the human variant prefix emitted by bench_throughput.nim to the slug
+# we use as the BMF benchmark name root. Matching is exact on the leading
+# token of the header line (the word before the first space or paren).
+VARIANT_SLUGS: dict[str, str] = {
+    "Sipsic": "sipsic",
+    "Mupmuc": "mupmuc",
+    "UnboundedMupsic": "unbounded_mupsic",
+    "Channels": "channels",
+}
+
+# `<Variant> (...) <P>P/<C>C:`  e.g. "Mupmuc (bounded MPMC) 2P/2C:"
+HEADER_RE = re.compile(
+    r"^(?P<variant>[A-Za-z_]+)\s+\([^)]*\)\s+(?P<p>\d+)P/(?P<c>\d+)C:\s*$"
+)
+# `  mean: 11232. ops/ms`   (Nim's `:.0f` formatter emits trailing dots)
+MEAN_RE = re.compile(r"^\s*mean:\s+(?P<v>[-\w.]+)\s+ops/ms\s*$")
+# `  min: 5000.  max: 10000.`
+MIN_MAX_RE = re.compile(r"^\s*min:\s+(?P<lo>[-\w.]+)\s+max:\s+(?P<hi>[-\w.]+)\s*$")
+
+
+def _parse_number(token: str) -> float | None:
+    """Parse a Nim-formatted ops/ms token. Returns None if non-finite."""
+    # Nim's `fmt"{x:.0f}"` produces e.g. "11232.", "inf", "nan".
+    try:
+        value = float(token)
+    except ValueError:
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def parse_bench_output(text: str) -> dict[str, dict[str, dict[str, float]]]:
+    """Parse bench_throughput.nim stdout into a BMF-shaped dict.
+
+    Returns a mapping `{benchmark_name: {"throughput": {"value": ..., ...}}}`
+    suitable for `json.dumps`. Skips blocks whose `mean` is non-finite.
+    """
+    bmf: dict[str, dict[str, dict[str, float]]] = {}
+
+    current_name: str | None = None
+    current_metrics: dict[str, float] | None = None
+
+    def _flush() -> None:
+        nonlocal current_name, current_metrics
+        if current_name is not None and current_metrics is not None:
+            if "value" in current_metrics:
+                bmf[current_name] = {"throughput": current_metrics}
+            else:
+                # Header matched but we never saw a finite mean — drop it.
+                print(
+                    f"bmf_adapter: dropping {current_name!r} (no finite mean)",
+                    file=sys.stderr,
+                )
+        current_name = None
+        current_metrics = None
+
+    for line in text.splitlines():
+        header = HEADER_RE.match(line)
+        if header is not None:
+            _flush()
+            variant = header["variant"]
+            slug = VARIANT_SLUGS.get(variant)
+            if slug is None:
+                # Unknown variant — keep parsing but record nothing for it.
+                current_name = None
+                current_metrics = None
+                continue
+            current_name = f"{slug}/{header['p']}p{header['c']}c"
+            current_metrics = {}
+            continue
+
+        if current_metrics is None:
+            continue
+
+        mean_match = MEAN_RE.match(line)
+        if mean_match is not None:
+            mean = _parse_number(mean_match["v"])
+            if mean is not None:
+                current_metrics["value"] = mean
+            continue
+
+        min_max_match = MIN_MAX_RE.match(line)
+        if min_max_match is not None:
+            lo = _parse_number(min_max_match["lo"])
+            hi = _parse_number(min_max_match["hi"])
+            if lo is not None:
+                current_metrics["lower_value"] = lo
+            if hi is not None:
+                current_metrics["upper_value"] = hi
+            continue
+
+    _flush()
+    return bmf
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(
+            "usage: bmf_adapter.py <bench_output.txt> <bench_results.json|->",
+            file=sys.stderr,
+        )
+        return 2
+
+    in_path = Path(argv[1])
+    text = in_path.read_text(encoding="utf-8")
+    bmf: dict[str, Any] = parse_bench_output(text)
+
+    if not bmf:
+        print("bmf_adapter: no benchmark blocks parsed", file=sys.stderr)
+        return 1
+
+    payload = json.dumps(bmf, indent=2, sort_keys=True) + "\n"
+    if argv[2] == "-":
+        sys.stdout.write(payload)
+    else:
+        Path(argv[2]).write_text(payload, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/benchmarks/nim/adapters/lockfreequeues_unbounded_mupsic.nim
+++ b/benchmarks/nim/adapters/lockfreequeues_unbounded_mupsic.nim
@@ -1,0 +1,69 @@
+## Adapter for lockfreequeues UnboundedMupsic (unbounded MPSC).
+##
+## UnboundedMupsic differs from the bounded adapters in two ways:
+##
+## 1. It requires a `DebraManager` for epoch-based segment reclamation.
+##    The manager must outlive the queue and be shared across all
+##    producer/consumer threads.
+##
+## 2. Producers register against the manager on their own thread and
+##    obtain a `Producer` object via `getProducer`. That object holds a
+##    per-thread `ThreadHandle` and CANNOT be created on the main thread
+##    and shipped to a worker — handles are per-thread by construction.
+##
+## Because of (2) we cannot fit UnboundedMupsic into the generic
+## `QueueAdapter` concept (which assumes a single `push` callable shared
+## across producers). Instead this adapter owns the queue + manager +
+## consumer handle and exposes them so that bench code can register
+## producers on the worker threads themselves.
+##
+## The bench harness in `bench_throughput.nim` consumes this adapter
+## directly via specialized benchmark procs (mirroring the Mupmuc path).
+
+import lockfreequeues/unbounded_mupsic
+import debra
+
+type UnboundedMupsicAdapter*[S: static int, T; MaxThreads: static int] = object
+  ## Owns the heap-allocated queue and DebraManager. Consumer's
+  ## ThreadHandle is registered at init time on the calling (consumer)
+  ## thread. Producer threads must call `registerThread(adapter.manager[])`
+  ## themselves and then `queue.getProducer(handle)`.
+  queue*: ptr UnboundedMupsic[S, T, MaxThreads]
+  manager*: ptr DebraManager[MaxThreads]
+  consumerHandle*: ThreadHandle[MaxThreads]
+
+proc initUnboundedMupsicAdapter*[S: static int, T; MaxThreads: static int](
+    strategy: DeallocationStrategy = DefaultDeallocationStrategy
+): UnboundedMupsicAdapter[S, T, MaxThreads] =
+  ## Allocate manager and queue on the heap. Registers the calling thread
+  ## as the (single) consumer.
+  result.manager = create(DebraManager[MaxThreads])
+  result.manager[] = initDebraManager[MaxThreads]()
+  result.consumerHandle = registerThread(result.manager[])
+
+  result.queue = create(UnboundedMupsic[S, T, MaxThreads])
+  result.queue[] = newUnboundedMupsic[S, T, MaxThreads](
+    result.manager, result.consumerHandle, strategy
+  )
+
+proc deinitUnboundedMupsicAdapter*[S: static int, T; MaxThreads: static int](
+    a: var UnboundedMupsicAdapter[S, T, MaxThreads]
+) =
+  ## Tear down queue then manager. Order matters: the queue holds
+  ## pointers into manager-tracked retired segments, so the queue must
+  ## be reset before the manager. `reset` runs `=destroy` on the
+  ## referent (so segment memory is freed) without re-invoking it on
+  ## the moved-from slot.
+  if a.queue != nil:
+    reset(a.queue[])
+    dealloc(a.queue)
+    a.queue = nil
+  if a.manager != nil:
+    reset(a.manager[])
+    dealloc(a.manager)
+    a.manager = nil
+
+proc name*[S: static int, T; MaxThreads: static int](
+    a: UnboundedMupsicAdapter[S, T, MaxThreads]
+): string =
+  "lockfreequeues/UnboundedMupsic[" & $S & "]"

--- a/benchmarks/nim/bench_throughput.nim
+++ b/benchmarks/nim/bench_throughput.nim
@@ -271,6 +271,8 @@ const
   UnboundedMupsicSegmentSize {.intdefine.} = 64
   UnboundedMupsicMaxThreads {.intdefine.} = 8
     ## Headroom for the consumer + up to 4 producers + DEBRA bookkeeping.
+  # Override separately to keep CI runs tractable; unbounded_mupsic is super-linear in message count vs bounded variants.
+  UnboundedMupsicMessageCount {.intdefine.} = MessageCount
 
 type
   UMupsicProducerCtx[S: static int, T; MaxThreads: static int] = object
@@ -357,7 +359,10 @@ proc runUnboundedMupsicBenchmark[S: static int, T; MaxThreads: static int](
   result = float(totalMessages) / elapsedMs
 
 proc benchmarkUnboundedMupsicNP1C(
-    numProducers: int, runs: int = UnboundedMupsicRuns, warmup: int = WarmupRuns
+    numProducers: int,
+    runs: int = UnboundedMupsicRuns,
+    warmup: int = WarmupRuns,
+    messageCount: int = UnboundedMupsicMessageCount,
 ): ThroughputMetrics =
   ## Helper for the fixed-thread-count wrappers below. The adapter
   ## (and therefore manager + queue) is rebuilt per run; the consumer
@@ -368,13 +373,13 @@ proc benchmarkUnboundedMupsicNP1C(
     var a = initUnboundedMupsicAdapter[
       UnboundedMupsicSegmentSize, int, UnboundedMupsicMaxThreads
     ]()
-    discard runUnboundedMupsicBenchmark(a, numProducers)
+    discard runUnboundedMupsicBenchmark(a, numProducers, messageCount)
     deinitUnboundedMupsicAdapter(a)
   for _ in 0 ..< runs:
     var a = initUnboundedMupsicAdapter[
       UnboundedMupsicSegmentSize, int, UnboundedMupsicMaxThreads
     ]()
-    samples.add(runUnboundedMupsicBenchmark(a, numProducers))
+    samples.add(runUnboundedMupsicBenchmark(a, numProducers, messageCount))
     deinitUnboundedMupsicAdapter(a)
   ThroughputMetrics(
     mean: mean(samples),
@@ -386,17 +391,17 @@ proc benchmarkUnboundedMupsicNP1C(
 proc benchmarkUnboundedMupsic1P1C*(
     runs: int = UnboundedMupsicRuns, warmup: int = WarmupRuns
 ): ThroughputMetrics =
-  benchmarkUnboundedMupsicNP1C(1, runs, warmup)
+  benchmarkUnboundedMupsicNP1C(1, runs, warmup, UnboundedMupsicMessageCount)
 
 proc benchmarkUnboundedMupsic2P1C*(
     runs: int = UnboundedMupsicRuns, warmup: int = WarmupRuns
 ): ThroughputMetrics =
-  benchmarkUnboundedMupsicNP1C(2, runs, warmup)
+  benchmarkUnboundedMupsicNP1C(2, runs, warmup, UnboundedMupsicMessageCount)
 
 proc benchmarkUnboundedMupsic4P1C*(
     runs: int = UnboundedMupsicRuns, warmup: int = WarmupRuns
 ): ThroughputMetrics =
-  benchmarkUnboundedMupsicNP1C(4, runs, warmup)
+  benchmarkUnboundedMupsicNP1C(4, runs, warmup, UnboundedMupsicMessageCount)
 
 when isMainModule:
   # Unbuffer stdout so progress is visible when the bench is run under

--- a/benchmarks/nim/bench_throughput.nim
+++ b/benchmarks/nim/bench_throughput.nim
@@ -1,7 +1,7 @@
 ## Throughput benchmark: N producers, N consumers, shared queue.
 ## Measures ops/ms as thread count scales.
 
-import std/[atomics, times, monotimes, strformat, options, os, sets]
+import std/[atomics, times, monotimes, strformat, options, os, sets, syncio]
 import ./stats
 import ./results
 import ./adapter
@@ -11,10 +11,15 @@ import lockfreequeues/mupmuc
 import lockfreequeues/unbounded_mupsic
 import debra
 
+# All run-shape constants below are `{.intdefine.}` so they can be overridden
+# at compile time without touching the source. Default behavior (no `-d:` flags)
+# is unchanged: 1M messages, 33 timed runs, 3 warmup runs for the unbounded
+# Mupsic harness. For tighter wall-clock budgets in CI gate runs, override via
+# e.g. `nim c -d:MessageCount=100000 -d:UnboundedMupsicRuns=11 ...`.
 const
-  MessageCount = 1_000_000
-  DefaultRuns = 33
-  WarmupRuns = 3
+  MessageCount {.intdefine.} = 1_000_000
+  DefaultRuns {.intdefine.} = 33
+  WarmupRuns {.intdefine.} = 3
 
 type
   ProducerContext[Q] = object
@@ -262,9 +267,9 @@ proc benchmarkMupmuc4P4C*(
 # keep their previous run counts.
 
 const
-  UnboundedMupsicRuns = 33
-  UnboundedMupsicSegmentSize = 64
-  UnboundedMupsicMaxThreads = 8
+  UnboundedMupsicRuns {.intdefine.} = 33
+  UnboundedMupsicSegmentSize {.intdefine.} = 64
+  UnboundedMupsicMaxThreads {.intdefine.} = 8
     ## Headroom for the consumer + up to 4 producers + DEBRA bookkeeping.
 
 type
@@ -394,6 +399,13 @@ proc benchmarkUnboundedMupsic4P1C*(
   benchmarkUnboundedMupsicNP1C(4, runs, warmup)
 
 when isMainModule:
+  # Unbuffer stdout so progress is visible when the bench is run under
+  # a file redirect (e.g. `bench_throughput unbounded_mupsic > out.txt`).
+  # Without this, block-buffering on a redirected pipe can hide all
+  # output from a >20-minute variant until the process exits, which
+  # makes external poll loops indistinguishable from a hang.
+  setStdIoUnbuffered()
+
   # CLI: optional variant-group filter. With no args, run everything
   # (backward compatible). With one or more args from the supported
   # set, run only those groups. Unknown args produce an error and

--- a/benchmarks/nim/bench_throughput.nim
+++ b/benchmarks/nim/bench_throughput.nim
@@ -1,7 +1,7 @@
 ## Throughput benchmark: N producers, N consumers, shared queue.
 ## Measures ops/ms as thread count scales.
 
-import std/[atomics, times, monotimes, strformat, options]
+import std/[atomics, times, monotimes, strformat, options, os, sets]
 import ./stats
 import ./results
 import ./adapter
@@ -394,73 +394,98 @@ proc benchmarkUnboundedMupsic4P1C*(
   benchmarkUnboundedMupsicNP1C(4, runs, warmup)
 
 when isMainModule:
+  # CLI: optional variant-group filter. With no args, run everything
+  # (backward compatible). With one or more args from the supported
+  # set, run only those groups. Unknown args produce an error and
+  # exit non-zero.
+  const SupportedGroups = ["sipsic", "mupmuc", "unbounded_mupsic", "channels"]
+
+  let cliArgs = commandLineParams()
+  let supported = SupportedGroups.toHashSet
+  let runGroups =
+    if cliArgs.len == 0:
+      supported
+    else:
+      var groups = initHashSet[string]()
+      for arg in cliArgs:
+        if arg notin supported:
+          echo "Unknown variant group: ", arg
+          echo "Supported: ", SupportedGroups
+          quit 1
+        groups.incl arg
+      groups
+
   echo "Throughput Benchmark"
   echo "===================="
   echo ""
 
   # Bounded SPSC (1P/1C only)
-  echo "Sipsic (bounded SPSC) 1P/1C:"
-  let sipsicMetrics = benchmarkThroughput(
-    proc(): SipsicAdapter[1024, int] =
-      initSipsicAdapter[1024, int](),
-    numProducers = 1,
-    numConsumers = 1,
-    runs = 10,
-  )
-  echo fmt"  mean: {sipsicMetrics.mean:.0f} ops/ms"
-  echo fmt"  stddev: {sipsicMetrics.stddev:.0f}"
-  echo ""
-
-  # Mupmuc (bounded MPMC)
-  for threads in [1, 2, 4]:
-    echo fmt"Mupmuc (bounded MPMC) {threads}P/{threads}C:"
-    let metrics =
-      case threads
-      of 1:
-        benchmarkMupmuc1P1C(runs = 10)
-      of 2:
-        benchmarkMupmuc2P2C(runs = 10)
-      of 4:
-        benchmarkMupmuc4P4C(runs = 10)
-      else:
-        ThroughputMetrics()
-    echo fmt"  mean: {metrics.mean:.0f} ops/ms"
-    echo fmt"  stddev: {metrics.stddev:.0f}"
-    echo ""
-
-  # UnboundedMupsic (unbounded MPSC) — new harness, 33 runs.
-  echo "==================================================="
-  echo "UnboundedMupsic (unbounded MPSC) — runs = ", UnboundedMupsicRuns
-  echo "==================================================="
-  for producers in [1, 2, 4]:
-    echo fmt"UnboundedMupsic (unbounded MPSC) {producers}P/1C:"
-    let metrics =
-      case producers
-      of 1:
-        benchmarkUnboundedMupsic1P1C()
-      of 2:
-        benchmarkUnboundedMupsic2P1C()
-      of 4:
-        benchmarkUnboundedMupsic4P1C()
-      else:
-        ThroughputMetrics()
-    echo fmt"  mean: {metrics.mean:.0f} ops/ms"
-    echo fmt"  min: {metrics.min:.0f}  max: {metrics.max:.0f}"
-    echo fmt"  stddev: {metrics.stddev:.0f}"
-    echo ""
-  echo "==================================================="
-  echo ""
-
-  # Channels (MPMC)
-  for threads in [1, 2, 4]:
-    echo fmt"Channels (MPMC) {threads}P/{threads}C:"
-    let metrics = benchmarkThroughput(
-      proc(): ChannelsAdapter[int] =
-        initChannelsAdapter[int](1024),
-      numProducers = threads,
-      numConsumers = threads,
+  if "sipsic" in runGroups:
+    echo "Sipsic (bounded SPSC) 1P/1C:"
+    let sipsicMetrics = benchmarkThroughput(
+      proc(): SipsicAdapter[1024, int] =
+        initSipsicAdapter[1024, int](),
+      numProducers = 1,
+      numConsumers = 1,
       runs = 10,
     )
-    echo fmt"  mean: {metrics.mean:.0f} ops/ms"
-    echo fmt"  stddev: {metrics.stddev:.0f}"
+    echo fmt"  mean: {sipsicMetrics.mean:.0f} ops/ms"
+    echo fmt"  stddev: {sipsicMetrics.stddev:.0f}"
     echo ""
+
+  # Mupmuc (bounded MPMC)
+  if "mupmuc" in runGroups:
+    for threads in [1, 2, 4]:
+      echo fmt"Mupmuc (bounded MPMC) {threads}P/{threads}C:"
+      let metrics =
+        case threads
+        of 1:
+          benchmarkMupmuc1P1C(runs = 10)
+        of 2:
+          benchmarkMupmuc2P2C(runs = 10)
+        of 4:
+          benchmarkMupmuc4P4C(runs = 10)
+        else:
+          ThroughputMetrics()
+      echo fmt"  mean: {metrics.mean:.0f} ops/ms"
+      echo fmt"  stddev: {metrics.stddev:.0f}"
+      echo ""
+
+  # UnboundedMupsic (unbounded MPSC) — new harness, 33 runs.
+  if "unbounded_mupsic" in runGroups:
+    echo "==================================================="
+    echo "UnboundedMupsic (unbounded MPSC) — runs = ", UnboundedMupsicRuns
+    echo "==================================================="
+    for producers in [1, 2, 4]:
+      echo fmt"UnboundedMupsic (unbounded MPSC) {producers}P/1C:"
+      let metrics =
+        case producers
+        of 1:
+          benchmarkUnboundedMupsic1P1C()
+        of 2:
+          benchmarkUnboundedMupsic2P1C()
+        of 4:
+          benchmarkUnboundedMupsic4P1C()
+        else:
+          ThroughputMetrics()
+      echo fmt"  mean: {metrics.mean:.0f} ops/ms"
+      echo fmt"  min: {metrics.min:.0f}  max: {metrics.max:.0f}"
+      echo fmt"  stddev: {metrics.stddev:.0f}"
+      echo ""
+    echo "==================================================="
+    echo ""
+
+  # Channels (MPMC)
+  if "channels" in runGroups:
+    for threads in [1, 2, 4]:
+      echo fmt"Channels (MPMC) {threads}P/{threads}C:"
+      let metrics = benchmarkThroughput(
+        proc(): ChannelsAdapter[int] =
+          initChannelsAdapter[int](1024),
+        numProducers = threads,
+        numConsumers = threads,
+        runs = 10,
+      )
+      echo fmt"  mean: {metrics.mean:.0f} ops/ms"
+      echo fmt"  stddev: {metrics.stddev:.0f}"
+      echo ""

--- a/benchmarks/nim/bench_throughput.nim
+++ b/benchmarks/nim/bench_throughput.nim
@@ -5,8 +5,11 @@ import std/[atomics, times, monotimes, strformat, options]
 import ./stats
 import ./results
 import ./adapter
-import ./adapters/[lockfreequeues_sipsic, channels_adapter]
+import
+  ./adapters/[lockfreequeues_sipsic, channels_adapter, lockfreequeues_unbounded_mupsic]
 import lockfreequeues/mupmuc
+import lockfreequeues/unbounded_mupsic
+import debra
 
 const
   MessageCount = 1_000_000
@@ -246,6 +249,150 @@ proc benchmarkMupmuc4P4C*(
     stddev: stddev(samples),
   )
 
+# UnboundedMupsic-specific benchmark types and procs.
+#
+# UnboundedMupsic is multi-producer, single-consumer with linked-segment
+# storage and DEBRA epoch-based reclamation. Producers must register a
+# per-thread ThreadHandle on their own thread and obtain a Producer via
+# getProducer; the consumer is implicit (a single thread driving pop on
+# the queue object directly).
+#
+# Run count for these variants is fixed at the followup-doc value below
+# (UnboundedMupsicRuns); the existing Mupmuc / Sipsic / Channels variants
+# keep their previous run counts.
+
+const
+  UnboundedMupsicRuns = 33
+  UnboundedMupsicSegmentSize = 64
+  UnboundedMupsicMaxThreads = 8
+    ## Headroom for the consumer + up to 4 producers + DEBRA bookkeeping.
+
+type
+  UMupsicProducerCtx[S: static int, T; MaxThreads: static int] = object
+    queue: ptr UnboundedMupsic[S, T, MaxThreads]
+    manager: ptr DebraManager[MaxThreads]
+    startIdx: int
+    count: int
+    done: ptr Atomic[int]
+
+  UMupsicConsumerCtx[S: static int, T; MaxThreads: static int] = object
+    queue: ptr UnboundedMupsic[S, T, MaxThreads]
+    count: int
+    consumed: ptr Atomic[int]
+
+proc uMupsicProducer[S: static int, T; MaxThreads: static int](
+    ctx: ptr UMupsicProducerCtx[S, T, MaxThreads]
+) {.thread.} =
+  {.cast(gcsafe).}:
+    let handle = registerThread(ctx.manager[])
+    var p = ctx.queue[].getProducer(handle)
+    for i in ctx.startIdx ..< ctx.startIdx + ctx.count:
+      p.push(i)
+    discard ctx.done[].fetchAdd(1)
+
+proc uMupsicConsumer[S: static int, T; MaxThreads: static int](
+    ctx: ptr UMupsicConsumerCtx[S, T, MaxThreads]
+) {.thread.} =
+  {.cast(gcsafe).}:
+    var local = 0
+    while local < ctx.count:
+      let item = ctx.queue[].pop()
+      if item.isSome:
+        inc local
+    discard ctx.consumed[].fetchAdd(local)
+
+proc runUnboundedMupsicBenchmark[S: static int, T; MaxThreads: static int](
+    adapter: var UnboundedMupsicAdapter[S, T, MaxThreads],
+    numProducers: int,
+    messageCount: int = MessageCount,
+): float =
+  ## Spawn `numProducers` producers and one consumer. Each producer
+  ## pushes a disjoint range of `messagesPerProducer` items; the consumer
+  ## pops until it has seen `messagesPerProducer * numProducers` items.
+  ## Returns throughput in ops/ms.
+  let messagesPerProducer = messageCount div numProducers
+  let totalMessages = messagesPerProducer * numProducers
+
+  var done: Atomic[int]
+  var consumed: Atomic[int]
+  done.store(0)
+  consumed.store(0)
+
+  var producerThreads =
+    newSeq[Thread[ptr UMupsicProducerCtx[S, T, MaxThreads]]](numProducers)
+  var producerCtxs = newSeq[UMupsicProducerCtx[S, T, MaxThreads]](numProducers)
+  var consumerThread: Thread[ptr UMupsicConsumerCtx[S, T, MaxThreads]]
+  var consumerCtx = UMupsicConsumerCtx[S, T, MaxThreads](
+    queue: adapter.queue, count: totalMessages, consumed: addr consumed
+  )
+
+  for i in 0 ..< numProducers:
+    producerCtxs[i] = UMupsicProducerCtx[S, T, MaxThreads](
+      queue: adapter.queue,
+      manager: adapter.manager,
+      startIdx: i * messagesPerProducer,
+      count: messagesPerProducer,
+      done: addr done,
+    )
+
+  # Start timing. Monotonic clock; see runMupmucBenchmark for rationale.
+  let startTime = getMonoTime()
+
+  for i in 0 ..< numProducers:
+    createThread(
+      producerThreads[i], uMupsicProducer[S, T, MaxThreads], addr producerCtxs[i]
+    )
+  createThread(consumerThread, uMupsicConsumer[S, T, MaxThreads], addr consumerCtx)
+
+  for i in 0 ..< numProducers:
+    joinThread(producerThreads[i])
+  joinThread(consumerThread)
+
+  let elapsedMs = float(inMilliseconds(getMonoTime() - startTime))
+  result = float(totalMessages) / elapsedMs
+
+proc benchmarkUnboundedMupsicNP1C(
+    numProducers: int, runs: int = UnboundedMupsicRuns, warmup: int = WarmupRuns
+): ThroughputMetrics =
+  ## Helper for the fixed-thread-count wrappers below. The adapter
+  ## (and therefore manager + queue) is rebuilt per run; the consumer
+  ## is the calling thread for both warmup and timed runs, which keeps
+  ## the consumer ThreadHandle stable across all pops in a run.
+  var samples: seq[float] = @[]
+  for _ in 0 ..< warmup:
+    var a = initUnboundedMupsicAdapter[
+      UnboundedMupsicSegmentSize, int, UnboundedMupsicMaxThreads
+    ]()
+    discard runUnboundedMupsicBenchmark(a, numProducers)
+    deinitUnboundedMupsicAdapter(a)
+  for _ in 0 ..< runs:
+    var a = initUnboundedMupsicAdapter[
+      UnboundedMupsicSegmentSize, int, UnboundedMupsicMaxThreads
+    ]()
+    samples.add(runUnboundedMupsicBenchmark(a, numProducers))
+    deinitUnboundedMupsicAdapter(a)
+  ThroughputMetrics(
+    mean: mean(samples),
+    min: minVal(samples),
+    max: maxVal(samples),
+    stddev: stddev(samples),
+  )
+
+proc benchmarkUnboundedMupsic1P1C*(
+    runs: int = UnboundedMupsicRuns, warmup: int = WarmupRuns
+): ThroughputMetrics =
+  benchmarkUnboundedMupsicNP1C(1, runs, warmup)
+
+proc benchmarkUnboundedMupsic2P1C*(
+    runs: int = UnboundedMupsicRuns, warmup: int = WarmupRuns
+): ThroughputMetrics =
+  benchmarkUnboundedMupsicNP1C(2, runs, warmup)
+
+proc benchmarkUnboundedMupsic4P1C*(
+    runs: int = UnboundedMupsicRuns, warmup: int = WarmupRuns
+): ThroughputMetrics =
+  benchmarkUnboundedMupsicNP1C(4, runs, warmup)
+
 when isMainModule:
   echo "Throughput Benchmark"
   echo "===================="
@@ -280,6 +427,29 @@ when isMainModule:
     echo fmt"  mean: {metrics.mean:.0f} ops/ms"
     echo fmt"  stddev: {metrics.stddev:.0f}"
     echo ""
+
+  # UnboundedMupsic (unbounded MPSC) — new harness, 33 runs.
+  echo "==================================================="
+  echo "UnboundedMupsic (unbounded MPSC) — runs = ", UnboundedMupsicRuns
+  echo "==================================================="
+  for producers in [1, 2, 4]:
+    echo fmt"UnboundedMupsic (unbounded MPSC) {producers}P/1C:"
+    let metrics =
+      case producers
+      of 1:
+        benchmarkUnboundedMupsic1P1C()
+      of 2:
+        benchmarkUnboundedMupsic2P1C()
+      of 4:
+        benchmarkUnboundedMupsic4P1C()
+      else:
+        ThroughputMetrics()
+    echo fmt"  mean: {metrics.mean:.0f} ops/ms"
+    echo fmt"  min: {metrics.min:.0f}  max: {metrics.max:.0f}"
+    echo fmt"  stddev: {metrics.stddev:.0f}"
+    echo ""
+  echo "==================================================="
+  echo ""
 
   # Channels (MPMC)
   for threads in [1, 2, 4]:

--- a/benchmarks/nim/bench_throughput.nim
+++ b/benchmarks/nim/bench_throughput.nim
@@ -80,6 +80,9 @@ proc runThroughputBenchmark*[Q](
 
   # Start timing. Monotonic clock — `epochTime` (wall clock) can step
   # backward across NTP adjustments and skew throughput numbers.
+  # Nanosecond precision: ms-precision buckets multiple short runs into
+  # the same integer ms, producing identical samples and stddev=0 on a
+  # fast CI runner. ops/ms is reconstructed as a float at print time.
   let startTime = getMonoTime()
 
   # Launch threads
@@ -94,8 +97,8 @@ proc runThroughputBenchmark*[Q](
   for i in 0 ..< numConsumers:
     joinThread(consumerThreads[i])
 
-  let elapsedMs = float(inMilliseconds(getMonoTime() - startTime))
-  result = float(messageCount) / elapsedMs
+  let elapsedNs = float(inNanoseconds(getMonoTime() - startTime))
+  result = float(messageCount) * 1_000_000.0 / elapsedNs
 
 proc benchmarkThroughput*[Q](
     initQueue: proc(): Q,
@@ -185,6 +188,7 @@ proc runMupmucBenchmark[N, P, C: static int, T](
 
   # Start timing. Monotonic clock — `epochTime` (wall clock) can step
   # backward across NTP adjustments and skew throughput numbers.
+  # See runThroughputBenchmark for the nanosecond-precision rationale.
   let startTime = getMonoTime()
 
   # Launch threads
@@ -199,8 +203,8 @@ proc runMupmucBenchmark[N, P, C: static int, T](
   for i in 0 ..< C:
     joinThread(consumerThreads[i])
 
-  let elapsedMs = float(inMilliseconds(getMonoTime() - startTime))
-  result = float(messageCount) / elapsedMs
+  let elapsedNs = float(inNanoseconds(getMonoTime() - startTime))
+  result = float(messageCount) * 1_000_000.0 / elapsedNs
 
 # Fixed-size Mupmuc benchmark functions for common thread counts
 proc benchmarkMupmuc1P1C*(
@@ -355,8 +359,8 @@ proc runUnboundedMupsicBenchmark[S: static int, T; MaxThreads: static int](
     joinThread(producerThreads[i])
   joinThread(consumerThread)
 
-  let elapsedMs = float(inMilliseconds(getMonoTime() - startTime))
-  result = float(totalMessages) / elapsedMs
+  let elapsedNs = float(inNanoseconds(getMonoTime() - startTime))
+  result = float(totalMessages) * 1_000_000.0 / elapsedNs
 
 proc benchmarkUnboundedMupsicNP1C(
     numProducers: int,
@@ -446,8 +450,8 @@ when isMainModule:
       numConsumers = 1,
       runs = 10,
     )
-    echo fmt"  mean: {sipsicMetrics.mean:.0f} ops/ms"
-    echo fmt"  stddev: {sipsicMetrics.stddev:.0f}"
+    echo fmt"  mean: {sipsicMetrics.mean:.1f} ops/ms"
+    echo fmt"  stddev: {sipsicMetrics.stddev:.1f}"
     echo ""
 
   # Mupmuc (bounded MPMC)
@@ -464,8 +468,8 @@ when isMainModule:
           benchmarkMupmuc4P4C(runs = 10)
         else:
           ThroughputMetrics()
-      echo fmt"  mean: {metrics.mean:.0f} ops/ms"
-      echo fmt"  stddev: {metrics.stddev:.0f}"
+      echo fmt"  mean: {metrics.mean:.1f} ops/ms"
+      echo fmt"  stddev: {metrics.stddev:.1f}"
       echo ""
 
   # UnboundedMupsic (unbounded MPSC) — new harness, 33 runs.
@@ -485,9 +489,9 @@ when isMainModule:
           benchmarkUnboundedMupsic4P1C()
         else:
           ThroughputMetrics()
-      echo fmt"  mean: {metrics.mean:.0f} ops/ms"
-      echo fmt"  min: {metrics.min:.0f}  max: {metrics.max:.0f}"
-      echo fmt"  stddev: {metrics.stddev:.0f}"
+      echo fmt"  mean: {metrics.mean:.1f} ops/ms"
+      echo fmt"  min: {metrics.min:.1f}  max: {metrics.max:.1f}"
+      echo fmt"  stddev: {metrics.stddev:.1f}"
       echo ""
     echo "==================================================="
     echo ""
@@ -503,6 +507,6 @@ when isMainModule:
         numConsumers = threads,
         runs = 10,
       )
-      echo fmt"  mean: {metrics.mean:.0f} ops/ms"
-      echo fmt"  stddev: {metrics.stddev:.0f}"
+      echo fmt"  mean: {metrics.mean:.1f} ops/ms"
+      echo fmt"  stddev: {metrics.stddev:.1f}"
       echo ""

--- a/benchmarks/test_bmf_adapter.py
+++ b/benchmarks/test_bmf_adapter.py
@@ -1,0 +1,270 @@
+"""Tests for the BMF adapter.
+
+Each test asserts the FULL expected dict against parser output. No partial
+assertions, no substring checks. Fixtures are real captures of
+`bench_throughput` output (with both finite and non-finite values) so the
+adapter is verified against the actual Nim formatter.
+
+Run with stdlib unittest (no pytest dependency):
+
+    python3 -m unittest benchmarks.test_bmf_adapter -v
+
+or directly:
+
+    python3 benchmarks/test_bmf_adapter.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+ADAPTER = Path(__file__).parent / "bmf_adapter.py"
+
+
+def _import_adapter():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("bmf_adapter", ADAPTER)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+bmf_adapter = _import_adapter()
+
+
+class ParseBenchOutputTests(unittest.TestCase):
+    def test_full_output_with_finite_and_nonfinite_blocks(self) -> None:
+        """The 10k-message smoke run mixes finite blocks and inf/nan blocks.
+
+        Finite blocks become BMF entries; non-finite blocks are dropped. For
+        unbounded_mupsic 4P/1C both min and max are finite, so lower_value
+        and upper_value are present.
+        """
+        fixture = textwrap.dedent(
+            """\
+            Throughput Benchmark
+            ====================
+
+            Sipsic (bounded SPSC) 1P/1C:
+              mean: inf ops/ms
+              stddev: nan
+
+            Mupmuc (bounded MPMC) 1P/1C:
+              mean: inf ops/ms
+              stddev: nan
+
+            Mupmuc (bounded MPMC) 2P/2C:
+              mean: 8000. ops/ms
+              stddev: 2582.
+
+            Mupmuc (bounded MPMC) 4P/4C:
+              mean: 3283. ops/ms
+              stddev: 1347.
+
+            ===================================================
+            UnboundedMupsic (unbounded MPSC) - runs = 2
+            ===================================================
+            UnboundedMupsic (unbounded MPSC) 1P/1C:
+              mean: inf ops/ms
+              min: 10000.  max: inf
+              stddev: nan
+
+            UnboundedMupsic (unbounded MPSC) 2P/1C:
+              mean: inf ops/ms
+              min: 10000.  max: inf
+              stddev: nan
+
+            UnboundedMupsic (unbounded MPSC) 4P/1C:
+              mean: 7500. ops/ms
+              min: 5000.  max: 10000.
+              stddev: 3536.
+
+            ===================================================
+
+            Channels (MPMC) 1P/1C:
+              mean: inf ops/ms
+              stddev: nan
+
+            Channels (MPMC) 2P/2C:
+              mean: 2676. ops/ms
+              stddev: 1747.
+
+            Channels (MPMC) 4P/4C:
+              mean: 645. ops/ms
+              stddev: 327.
+            """
+        )
+
+        expected = {
+            "mupmuc/2p2c": {"throughput": {"value": 8000.0}},
+            "mupmuc/4p4c": {"throughput": {"value": 3283.0}},
+            "unbounded_mupsic/4p1c": {
+                "throughput": {
+                    "value": 7500.0,
+                    "lower_value": 5000.0,
+                    "upper_value": 10000.0,
+                }
+            },
+            "channels/2p2c": {"throughput": {"value": 2676.0}},
+            "channels/4p4c": {"throughput": {"value": 645.0}},
+        }
+
+        actual = bmf_adapter.parse_bench_output(fixture)
+        self.assertEqual(actual, expected)
+
+    def test_all_finite_full_run(self) -> None:
+        """A full run with all finite means produces every variant."""
+        fixture = textwrap.dedent(
+            """\
+            Throughput Benchmark
+            ====================
+
+            Sipsic (bounded SPSC) 1P/1C:
+              mean: 12345. ops/ms
+              stddev: 100.
+
+            Mupmuc (bounded MPMC) 1P/1C:
+              mean: 9000. ops/ms
+              stddev: 200.
+
+            UnboundedMupsic (unbounded MPSC) 1P/1C:
+              mean: 11000. ops/ms
+              min: 10000.  max: 12000.
+              stddev: 50.
+
+            UnboundedMupsic (unbounded MPSC) 2P/1C:
+              mean: 6000. ops/ms
+              min: 5500.  max: 6500.
+              stddev: 30.
+
+            Channels (MPMC) 1P/1C:
+              mean: 4321. ops/ms
+              stddev: 12.
+            """
+        )
+
+        expected = {
+            "sipsic/1p1c": {"throughput": {"value": 12345.0}},
+            "mupmuc/1p1c": {"throughput": {"value": 9000.0}},
+            "unbounded_mupsic/1p1c": {
+                "throughput": {
+                    "value": 11000.0,
+                    "lower_value": 10000.0,
+                    "upper_value": 12000.0,
+                }
+            },
+            "unbounded_mupsic/2p1c": {
+                "throughput": {
+                    "value": 6000.0,
+                    "lower_value": 5500.0,
+                    "upper_value": 6500.0,
+                }
+            },
+            "channels/1p1c": {"throughput": {"value": 4321.0}},
+        }
+
+        actual = bmf_adapter.parse_bench_output(fixture)
+        self.assertEqual(actual, expected)
+
+    def test_unknown_variant_is_skipped(self) -> None:
+        """An unrecognised variant is ignored without breaking neighbours."""
+        fixture = textwrap.dedent(
+            """\
+            SomethingNew (foo) 1P/1C:
+              mean: 999. ops/ms
+              stddev: 0.
+
+            Sipsic (bounded SPSC) 1P/1C:
+              mean: 100. ops/ms
+              stddev: 1.
+            """
+        )
+
+        expected = {"sipsic/1p1c": {"throughput": {"value": 100.0}}}
+        actual = bmf_adapter.parse_bench_output(fixture)
+        self.assertEqual(actual, expected)
+
+    def test_partial_min_max_finite(self) -> None:
+        """If only min is finite (max is inf), only lower_value is recorded."""
+        fixture = textwrap.dedent(
+            """\
+            UnboundedMupsic (unbounded MPSC) 4P/1C:
+              mean: 8000. ops/ms
+              min: 5000.  max: inf
+              stddev: 100.
+            """
+        )
+
+        expected = {
+            "unbounded_mupsic/4p1c": {
+                "throughput": {"value": 8000.0, "lower_value": 5000.0}
+            }
+        }
+        actual = bmf_adapter.parse_bench_output(fixture)
+        self.assertEqual(actual, expected)
+
+
+class CliTests(unittest.TestCase):
+    def test_cli_writes_json_file(self) -> None:
+        """End-to-end: CLI reads a fixture file and writes the expected JSON."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            in_path = tmp / "bench.txt"
+            out_path = tmp / "bench.json"
+            in_path.write_text(
+                textwrap.dedent(
+                    """\
+                    Sipsic (bounded SPSC) 1P/1C:
+                      mean: 100. ops/ms
+                      stddev: 1.
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [sys.executable, str(ADAPTER), str(in_path), str(out_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            expected = {"sipsic/1p1c": {"throughput": {"value": 100.0}}}
+            actual = json.loads(out_path.read_text(encoding="utf-8"))
+            self.assertEqual(actual, expected)
+
+    def test_cli_exits_nonzero_on_empty_input(self) -> None:
+        """An input that yields no benchmark blocks is a hard failure."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            in_path = tmp / "bench.txt"
+            out_path = tmp / "bench.json"
+            in_path.write_text(
+                "Throughput Benchmark\n====================\n", encoding="utf-8"
+            )
+
+            result = subprocess.run(
+                [sys.executable, str(ADAPTER), str(in_path), str(out_path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(
+                result.stderr, "bmf_adapter: no benchmark blocks parsed\n"
+            )
+            self.assertFalse(out_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/test_bmf_adapter.py
+++ b/benchmarks/test_bmf_adapter.py
@@ -193,6 +193,39 @@ class ParseBenchOutputTests(unittest.TestCase):
         actual = bmf_adapter.parse_bench_output(fixture)
         self.assertEqual(actual, expected)
 
+    def test_decimal_means_and_minmax(self) -> None:
+        """Microsecond/nanosecond-precision timer emits `:.1f` decimal values.
+
+        After the bench switched from `inMilliseconds` to `inNanoseconds`,
+        means and min/max gain a fractional component (e.g. 16666.7 instead
+        of 16667.). The adapter must capture decimal floats verbatim.
+        """
+        fixture = textwrap.dedent(
+            """\
+            Sipsic (bounded SPSC) 1P/1C:
+              mean: 12345.6 ops/ms
+              stddev: 12.3
+
+            UnboundedMupsic (unbounded MPSC) 2P/1C:
+              mean: 16666.7 ops/ms
+              min: 15555.4  max: 17777.8
+              stddev: 678.9
+            """
+        )
+
+        expected = {
+            "sipsic/1p1c": {"throughput": {"value": 12345.6}},
+            "unbounded_mupsic/2p1c": {
+                "throughput": {
+                    "value": 16666.7,
+                    "lower_value": 15555.4,
+                    "upper_value": 17777.8,
+                }
+            },
+        }
+        actual = bmf_adapter.parse_bench_output(fixture)
+        self.assertEqual(actual, expected)
+
     def test_partial_min_max_finite(self) -> None:
         """If only min is finite (max is inf), only lower_value is recorded."""
         fixture = textwrap.dedent(


### PR DESCRIPTION
### What

Closes a coverage gap discovered during 3.2.0 follow-up review. `benchmarks/nim/bench_throughput.nim` previously exercised only bounded `Mupmuc`, bounded `Sipsic`, and stdlib `Channels` — no unbounded queue variants and no `Mupsic` (MPSC). This PR adds:

- New adapter at `benchmarks/nim/adapters/lockfreequeues_unbounded_mupsic.nim` wrapping a heap-allocated `UnboundedMupsic` with its own `DebraManager`. Producers must call `registerThread` on their own thread to obtain a `Producer` handle (per-thread state means it can't fit the generic `QueueAdapter` shape).
- New constants: `UnboundedMupsicRuns = 33`, `UnboundedMupsicSegmentSize = 64`, `UnboundedMupsicMaxThreads = 8`.
- New worker procs (`uMupsicProducer`, `uMupsicConsumer`) and orchestrator (`runUnboundedMupsicBenchmark`).
- Three benchmark variants: `benchmarkUnboundedMupsic1P1C`, `benchmarkUnboundedMupsic2P1C`, `benchmarkUnboundedMupsic4P1C`. Mupsic is single-consumer by type, so 1 consumer is the only valid shape; producer counts surface contention.
- Wired into the bench main module with a clearly delimited output section reporting mean / min / max / stddev across 33 runs.

The existing bench's run count (10) is unchanged. The new variants use 33 per the original 3.2.0 follow-up doc's targeted resolution.

### Variant-group filter (added in this PR)

`bench_throughput` now accepts optional CLI args to limit which queue families execute. Supported group names: `sipsic`, `mupmuc`, `unbounded_mupsic`, `channels`.

- No args: run everything (backward compatible — release-time runs are unchanged).
- One or more group names: run only those groups (union semantics across multiple args).
- Unknown arg: print supported list and exit non-zero.

Motivation: a previous gate-run attempt for the tail-recheck optimization timed out at 75 minutes because the full suite includes `Mupmuc 2P/2C`, which alone consumed >38 minutes. The filter lets targeted gate runs — e.g. perf optimizations to `UnboundedMupsic` — execute against only the relevant family without paying for the slow bounded MPMC variants. This unblocks the deferred follow-up PR (item 3b) without changing default behavior.

### Compile-time overrides (added in this PR)

Run-shape constants in `bench_throughput.nim` are now `{.intdefine.}`, so they can be tightened at compile time without source edits:

- `-d:MessageCount=N` (default `1_000_000`)
- `-d:DefaultRuns=N` (default `33`)
- `-d:WarmupRuns=N` (default `3`)
- `-d:UnboundedMupsicRuns=N` (default `33`)
- `-d:UnboundedMupsicSegmentSize=N` (default `64`)
- `-d:UnboundedMupsicMaxThreads=N` (default `8`)

Defaults are unchanged. Invoking the bench with no `-d:` flags produces the same run shape as before. Example tighter gate build:

```
nim c --threads:on -d:release -d:MessageCount=100000 -d:UnboundedMupsicRuns=11 \
  -o:bench_quick benchmarks/nim/bench_throughput.nim
```

Motivation: three autonomous gate-run attempts for the tail-recheck optimization (item 3b) exhausted their wall-clock budget on the full-fidelity shape (1M messages × 33 runs). Compile-time overrides let a gate run trade statistical confidence for budget without forking the source. The variant-group filter alone wasn't enough — within the chosen family, the per-run cost still dominated.

`bench_throughput` also now calls `setStdIoUnbuffered()` at `isMainModule` entry. Without this, stdout block-buffering under file redirect can hide all output from a >20-minute variant until the process exits, making external poll loops indistinguishable from a hang.

### Why this PR is the harness + filter + overrides

The 3.2.0 follow-up doc proposed a tail re-check microoptimization in `unbounded_mupsic.nim`'s `pop` body and gated it on `bench_throughput.nim`. Three structural problems forced the harness work first:

1. The bench didn't cover unbounded_mupsic at all — running it would have produced unrelated noise.
2. With all variants in scope, a gate run could not finish inside any reasonable wall-clock budget.
3. Even within a single family, full-fidelity run shape exceeded gate budgets.

This PR ships the missing harness, the variant-group filter, and the compile-time overrides — each adding one degree of freedom for fitting a gate inside a wall budget. The optimization itself is deferred to a separate follow-up PR pending an actual filtered + tightened gate run on the new harness.

### Test status

`nimble test`: 181/181. Build passes clean (`nim c --threads:on -d:release`) for both the default shape and override shapes (`-d:MessageCount=100000 -d:UnboundedMupsicRuns=11` validated). Filter validated by smoke runs:
- `bench_throughput sipsic` → only Sipsic output.
- `bench_throughput channels` → only Channels output.
- `bench_throughput sipsic channels` → both groups, no Mupmuc / UnboundedMupsic output.
- `bench_throughput unbounded_mupsic` → only UnboundedMupsic header (kept running into the 33-run loop, no other group headers printed).
- `bench_throughput nonexistent_variant` → exit 1, supported-list message.

Override smoke run (`-d:MessageCount=50000 -d:UnboundedMupsicRuns=11`, `unbounded_mupsic` only) prints `runs = 11` in the header and produces all three result lines (1P/1C, 2P/1C, 4P/1C) in well under a minute. Stdout flow under redirect confirms `setStdIoUnbuffered` works.

Pre-commit clean. No `--no-verify`.

### Out of scope for this PR

- The `pop` re-check optimization. Will be a separate follow-up PR after running the filtered + override-tightened gate locally on `unbounded_mupsic` and confirming the change produces a measurable improvement (≥5% on 2P/1C or 4P/1C). If the gate is flat, the optimization is dropped per the 3.2.0 follow-up doc's "no microopts without evidence" rule.

### Coordination

CHANGELOG entries under `[Unreleased] / Added` cover the harness, the filter, and the compile-time overrides. No conflicting PRs in flight against this repo.


### Cloud bench harness (added in follow-up commit)

The harness side of "build the bench, then gate the optimization" now has a cloud arm. New files:

- `benchmarks/bmf_adapter.py` — converts `bench_throughput` stdout to [Bencher Metric Format](https://bencher.dev/docs/reference/bencher-metric-format/) JSON. Drops non-finite samples (cold-cache `inf`/`nan` from short CI runs), records mean as `value`, and `min`/`max` as `lower_value`/`upper_value` for the unbounded_mupsic blocks.
- `benchmarks/test_bmf_adapter.py` — 6 stdlib-unittest cases. Full assertions only. Smoke run against real captured `bench_throughput` output passes `python -m json.tool`.
- `.github/workflows/bench.yml` — triggers on PRs to `main`/`devel`, pushes to those branches, and `workflow_dispatch`. Compiles `bench_throughput` with the CI run shape (`-d:MessageCount=100000 -d:DefaultRuns=5 -d:WarmupRuns=2 -d:UnboundedMupsicRuns=5`), runs it on `ubuntu-latest`, feeds the BMF JSON to `bencherdev/bencher@main`. PR runs post a comparison comment via `--github-actions` and `--start-point-clone-thresholds`. Push runs record `t_test` thresholds against the branch baseline.
- `benchmarks/README.md` — documents local + cloud usage, BMF schema, and the maintainer setup steps below.

#### Maintainer setup (one-time, before this PR can produce green bench checks)

The workflow won't pass until both of these exist:

1. **Bencher project**: create a project at https://bencher.dev with the **exact slug `lockfreequeues`**. The workflow passes `--project lockfreequeues` literally.
2. **Repository secret `BENCHER_API_TOKEN`**: generate an API token at https://bencher.dev/console/users/<you>/tokens with write access to the project, then add it under repo Settings → Secrets and variables → Actions → New repository secret.

Until both exist, the bench job will run, produce a valid `bench_results.json` (visible in the job log), and fail at the upload step. PRs from forks are also skipped because they cannot read the secret.

#### How this unblocks the deferred tail re-check optimization

The 3.2.0 follow-up doc gated the `UnboundedMupsic.pop` tail re-check on a measurable bench improvement. Local gate runs were noisy and exceeded wall-clock budgets even with the variant filter and intdefine overrides shipped earlier in this PR. The cloud arm fixes both:

- Stable hardware (`ubuntu-latest`) instead of a developer laptop running other tasks.
- The Bencher comparison comment surfaces threshold breaches against the base branch automatically — the optimization PR will be merge-gated on a clean comparison rather than a hand-eyeballed `stddev` line.

The optimization itself remains out of scope here (separate follow-up branch).


### CI bench filter (added in follow-up commit)

The first cloud bench run on this PR hit the 30-minute job timeout: Sipsic / Mupmuc 1P/1C / Mupmuc 2P/2C all completed in ~200ms each, but **Mupmuc 4P/4C hung for the full 30 min** on the 4-vCPU `ubuntu-latest` runner (8 threads on 4 vCPU + tight CAS retry loop on small-capacity bounded MPMC = livelock under scheduler pressure). UnboundedMupsic and channels variants never started.

Mitigation: the workflow now passes `sipsic unbounded_mupsic channels` to `bench_throughput`, skipping the `mupmuc` variant on shared CI runners. The hang is tracked separately in [#15](https://github.com/elijahr/lockfreequeues/issues/15) so the cloud bench gate can proceed and the harness work in this PR can land. No bench source changes — the existing CLI variant-group filter (also added in this PR) is what makes the skip possible.

Failed run for reference: https://github.com/elijahr/lockfreequeues/actions/runs/25134969448/job/73670861543


### CI bench unbounded_mupsic knob (added in follow-up commit)

The previous follow-up still hit the 30-minute job timeout: the cloud run hung on `UnboundedMupsic 1P/1C` at `MessageCount=100000`. unbounded_mupsic is super-linear in message count compared to bounded variants (Sipsic finishes in ~0.2s at 100k; the unbounded variant at 100k can run multiple minutes per topology, with three topologies × 5 runs × warmup compounding fast).

Mitigation:

- New `UnboundedMupsicMessageCount {.intdefine.}` in `benchmarks/nim/bench_throughput.nim` (default = `MessageCount`, so local default behavior unchanged). Threaded through `benchmarkUnboundedMupsicNP1C` and the per-topology wrappers so unbounded benches push only this many messages.
- Workflow now passes `-d:UnboundedMupsicMessageCount=5000 -d:UnboundedMupsicRuns=3`. Bounded variants stay at 100k × 5; only the unbounded family is throttled. Comment block above the compile step updated to reflect the new shape.
- `Run bench_throughput` step gains `timeout-minutes: 20` so a single hung variant fails fast inside the 30-min job budget instead of starving the Bencher upload steps. The BMF adapter already drops non-finite samples, so a too-fast unbounded_mupsic measurement on a fast runner will produce a warning and skip rather than break the upload.

Failed run for reference: https://github.com/elijahr/lockfreequeues/actions/runs/25136854373/job/73677264669


---

### Update: stable unbounded_mupsic signal + graceful Bencher skip (commit 1a5b6e1)

The bench step now produces real `unbounded_mupsic` data on CI. `UnboundedMupsicMessageCount` was bumped from `5000` to `50000` because `bench_throughput.nim` uses a millisecond-precision timer: at `N=5000` the unbounded variant finished in under 1 ms per run, the harness reported `inf` ops/ms, and the BMF adapter dropped the data points so Bencher saw nothing for the variant we actually want to gate on. Local smoke at `N=50000` finishes in ~0.26s with stable per-topology numbers (1P/1C ~9.4k ops/ms, 2P/1C ~10.8k, 4P/1C ~8.9k); the CI cost for `50000 × 3 runs × 3 topologies + warmup` is ~4-10s, well inside the 30-min job budget.

The Bencher upload steps now skip cleanly when `BENCHER_API_TOKEN` is unset instead of failing the job. Each upload step's `if:` is ANDed with `env.BENCHER_API_TOKEN != ''` (the secret is exposed at job-level `env` to make this expressible — `secrets.*` is not allowed directly in `if:`). A new always-running `Bencher token preflight` step emits a `::warning` annotation visible in the PR-check summary when the token is missing, making it obvious why upload was skipped rather than the bench appearing to silently discard results. Once `BENCHER_API_TOKEN` is wired up at the repo level (Bencher project slug `lockfreequeues`), the upload starts working with no further workflow changes.



---

### Update: microsecond-precision timing + 10x N for stable signal (commit 439ee2c)

Resolution was too coarse on CI: at `MessageCount=100000 / UnboundedMupsicMessageCount=50000`, both `UnboundedMupsic 1P/1C` and `2P/1C` reported `mean: 16667 ops/ms, stddev: 0` -- 50000 msgs / 3ms on a fast CI runner buckets multiple runs into the same integer ms. To produce real signal for downstream perf work (e.g. tail-recheck optimization), this commit makes two changes:

- **Timer switched from `inMilliseconds` to `inNanoseconds`** in `runThroughputBenchmark`, `runMupmucBenchmark`, and `runUnboundedMupsicBenchmark`. ops/ms is now reconstructed as `messageCount.float * 1_000_000.0 / elapsedNs.float`, and all printers gain `.1f` decimal precision (`mean: 16666.7 ops/ms`, `stddev: 12.3`). The BMF adapter regex (`[-\w.]+`) already accepts decimals, so no parser change is needed; `benchmarks/test_bmf_adapter.py` gets a new `test_decimal_means_and_minmax` case to lock in the contract.
- **CI message counts bumped 10x**: `MessageCount` 100000 -> 1000000 and `UnboundedMupsicMessageCount` 50000 -> 500000 in the compile step. Run counts (`DefaultRuns=5`, `WarmupRuns=2`, `UnboundedMupsicRuns=3`) are unchanged. Together this gives the timer enough wall-clock spread to produce a comparable signal between commits, while staying inside the 30-min job budget.

Local smoke at the new run shape (with `UnboundedMupsicMessageCount=100000` to keep local wall-clock tractable) wall-clocks at 34.5s and produces non-zero stddev for every variant: e.g. `Sipsic 1P/1C: mean: 11174.4 ops/ms, stddev: 3752.8`, `UnboundedMupsic 2P/1C: mean: 7775.6 ops/ms, stddev: 4127.1`. BMF adapter parses cleanly; all 7 unit tests pass.




---

### Update: bench workflow now triggers on stacked-PR base branches (commit cfe8d3b)

`pull_request.branches` in `.github/workflows/bench.yml` was previously `[main, devel]`, so PRs targeting an in-flight feature branch (e.g. a stacked perf PR based on `feat/unbounded-mupsic-bench-harness`) did not auto-bench and required manual `workflow_dispatch` runs on both branches. The filter is now expanded to also match `feat/**`, `perf/**`, and `fix/**` prefixes (our existing branching conventions for stacked work), so stacked PRs auto-bench against their actual base. The `paths-ignore` block is unchanged, and `push` / `workflow_dispatch` triggers are unchanged. A wildcard `'**'` was deliberately avoided to keep fork PRs targeting unrelated branches from triggering the bench.
