### PR TITLE
perf(unbounded_mupsic): tail re-check before segment advance

### DIFF
--- a/src/lockfreequeues/unbounded_mupsic.nim
+++ b/src/lockfreequeues/unbounded_mupsic.nim
@@ -274,6 +274,14 @@ proc pop*[S: static int, T; MaxThreads: static int](
       if nextSeg == nil:
         break
 
+      # Tail re-check: a producer may have committed a slot between our
+      # original `tail` read above and now. Don't advance past data we
+      # could still pop. Loop back to re-evaluate `seg.head < tail` with
+      # the fresher tail value before retiring this segment.
+      let tailRecheck = seg.tail.load(moAcquire)
+      if seg.head < tailRecheck:
+        continue
+
       # Single consumer, so no race on headSegment. Advance with release
       # semantics and retire under the active pin so a follow-up reclaim
       # cannot free this segment until every pinned thread observes the


### PR DESCRIPTION
Applies item 3b from the post-3.2.0 follow-ups: in `UnboundedMupsic.pop`, after observing `seg.head >= tail` and confirming a `nextSeg` exists, re-read `seg.tail` immediately before retiring the current segment. If a producer committed in the meantime (`seg.head < tailRecheck`), `continue` the outer `while true` loop instead of advancing past data we could still pop.

This is mupsic-specific because it's the only single-consumer / single-segment-advance combination — sipmuc/sipsic don't have multi-producer concurrent commits racing against the consumer's exhaustion check.

The cost on the empty-segment hot path is a single extra acquire load (the original tail load is already in cache). The benefit, if any, is avoiding a needless segment retirement + DEBRA-managed reclaim in the window where producers are committing right at the boundary.

Per the follow-ups doc: "Confirm it's actually a measurable improvement under contention with `benchmarks/nim/bench_throughput.nim` before keeping the change — if there's no benchmark delta, drop it." This PR exists to gate that decision via Bencher.

## Dependency and merge plan

Depends on the cloud bench harness (the prior bench-harness PR). Targeting that PR's branch as the base isolates the perf delta in Bencher's comparison so we see only this optimization's effect, not the harness churn.

Merge plan:
1. Bencher run on this PR (compares against the bench-harness baseline)
2. Read 2P/1C and 4P/1C deltas — the multi-producer hot path is the gate
3. If signal: merge the bench-harness PR first, then rebase this onto devel and merge
4. If noise: close this PR, drop the optimization

Local `nimble test`: 181/181 passing. No behavior change expected — the tail re-check is a pure short-circuit; if the producer hasn't actually committed, the loop falls through to the original retire-and-advance path on the next iteration.