### PR TITLE
PR 1: bench_latency wired to BMF (smoke shape, multi-measure-per-slug)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -236,6 +236,8 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: [bench-throughput, bench-latency]
     permissions:
+      contents: read
+      actions: read
       pull-requests: write
       checks: write
     timeout-minutes: 10
@@ -248,14 +250,17 @@ jobs:
         # Pattern matches both bench-throughput-bmf and bench-latency-bmf
         # (and any future per-binary artifact uploaded by PR 2's topology
         # split, which uses the same `bench-*-bmf` naming convention).
+        # Each artifact downloads into its own subdirectory under
+        # `bmf-inputs/<artifact-name>/` (no `merge-multiple`) so two
+        # artifacts that happen to contain a same-named file (e.g. both
+        # write `throughput.json`) cannot overwrite each other.
         uses: actions/download-artifact@v4
         with:
           pattern: bench-*-bmf
           path: ./bmf-inputs/
-          merge-multiple: true
 
       - name: List BMF inputs (debug)
-        run: ls -la bmf-inputs/
+        run: find bmf-inputs/ -type f -name '*.json' -print
 
       - name: Merge BMF JSON
         # `merge_bmf.py` unions per-slug measure dicts across N inputs and
@@ -263,16 +268,12 @@ jobs:
         # party deps), so no Python install step is needed beyond the
         # ubuntu-latest default.
         #
-        # `$(ls ...)` is intentionally unquoted: each path must arrive as
-        # a separate positional argv to merge_bmf.py. shellcheck SC2046
-        # flags this as a word-splitting risk; the risk is real ONLY if
-        # an artifact filename contains whitespace or glob characters.
-        # Artifacts are produced by upload-artifact@v4 with names we
-        # control (`throughput.json`, `latency.json`); none contain
-        # whitespace, so the warning does not apply here.
+        # Inputs live one subdir deep (no `merge-multiple`); enumerate
+        # all `*.json` recursively. `xargs` arranges argv splitting; we
+        # NUL-delimit to be robust against any future filename quirks.
         run: |
-          # shellcheck disable=SC2046
-          python3 benchmarks/merge_bmf.py merged.json $(ls bmf-inputs/*.json)
+          find bmf-inputs/ -type f -name '*.json' -print0 | \
+            xargs -0 python3 benchmarks/merge_bmf.py merged.json
 
       - name: Show BMF JSON (debug)
         run: cat merged.json

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -75,15 +75,12 @@ jobs:
       - name: Run bench harness tests
         run: nimble benchtests
 
-  benchmark:
+  bench-throughput:
     name: Throughput bench (ubuntu-latest)
     runs-on: ubuntu-latest
     # PRs from forks cannot read BENCHER_API_TOKEN. Skip rather than fail
     # noisily; maintainer pushes / merges still record the baseline.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      pull-requests: write
-      checks: write
     timeout-minutes: 30
 
     steps:
@@ -91,7 +88,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${HOME}/.cache
-          key: cache-bench-${{ runner.os }}
+          key: cache-bench-throughput-${{ runner.os }}
 
       - name: Checkout project
         uses: actions/checkout@v4
@@ -131,16 +128,6 @@ jobs:
         # UnboundedMupsicMessageCount=500000 + UnboundedMupsicRuns=3 to keep
         # the variant tractable inside the 30-min job budget. Warmup stays
         # at 2 to absorb JIT/cache effects.
-        #
-        # Counts are 10x the previous values (100k / 50k → 1M / 500k) and
-        # the bench timer is microsecond/nanosecond-precision (computed in
-        # ns, printed as `mean: <N>.1f ops/ms`). Together this gives non-zero
-        # stddev and >1-decimal resolution between runs on the fast CI
-        # runner; previously a 50k unbounded_mupsic run completed in ~3 ms,
-        # so multiple samples bucketed into the same integer ms and stddev
-        # was reported as 0. The new shape costs roughly 30-60s on CI: well
-        # inside the 30-min job budget while giving the timer enough
-        # wall-clock spread to produce a stable, comparable signal.
         run: |
           nim c -d:release -d:danger --threads:on \
             -d:MessageCount=1000000 \
@@ -151,24 +138,141 @@ jobs:
             benchmarks/nim/bench_throughput.nim
 
       - name: Run bench_throughput
-        # mupmuc 4P/4C livelock fixed via CAS-retry backoff; ref issue #15.
-        # Step-level timeout: if any single variant hangs, fail fast inside
-        # the 30-min job budget so Bencher upload steps still run (or are
-        # visibly skipped) instead of burning the entire budget on one variant.
-        # `--bmf-out=throughput.json` emits Bencher Metric Format JSON
-        # natively (Task 0.10); the legacy stdout->bmf_adapter.py regex
-        # parser is gone (Task 0.12).
+        # mupmuc 4P/4C livelock fixed via CAS-retry backoff; see backoff
+        # changelog. Step-level timeout: if any single variant hangs, fail
+        # fast inside the 30-min job budget so the upload step still
+        # records the partial result rather than burning the entire
+        # budget on one variant.
         timeout-minutes: 20
         run: |
           ./.tmp/bench_throughput --bmf-out=throughput.json \
             sipsic mupmuc unbounded_mupsic channels | tee bench_output.txt
 
+      - name: Upload throughput BMF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-throughput-bmf
+          path: throughput.json
+
+  bench-latency:
+    # Sibling job to bench-throughput. Builds bench_latency.nim and emits a
+    # latency.json BMF fragment that the bench-upload job merges with the
+    # throughput fragment before a single `bencher run` upload — multiple
+    # `bencher run` invocations create separate Bencher Reports and would
+    # NOT co-locate latency + throughput measures on the shared per-slug
+    # history (design 1 / impl plan Track 1).
+    name: Latency bench (ubuntu-latest)
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 12
+
+    steps:
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: ${HOME}/.cache
+          key: cache-bench-latency-${{ runner.os }}
+
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Setup Nim
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: 'stable'
+
+      - name: Install build deps (Linux)
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get -qq install -y clang
+
+      - name: Clone and install sibling Nim deps (nim-debra, nim-typestates)
+        run: |
+          set -e
+          cd ..
+          git clone --depth 1 --branch main https://github.com/elijahr/nim-debra.git
+          git clone --depth 1 --branch main https://github.com/elijahr/nim-typestates.git
+          (cd nim-typestates && nimble install -y)
+          (cd nim-debra && nimble install -y)
+
+      - name: Vendor unittest2
+        run: git clone --depth 1 https://github.com/status-im/nim-unittest2.git deps/unittest2
+
+      - name: Compile bench_latency (CI-tuned run shape)
+        # 100K-message default × 33 runs would bust the 12-min budget on a
+        # CI runner with one ping-pong RTT pair per run. Cloud uses a
+        # tighter shape: 50K × 11 runs × 2 warmup ≈ 1.5M total RTTs across
+        # 4 variants. Each RTT is sub-microsecond on Linux x86_64; that
+        # gives ~3-4s per variant, well inside the budget.
+        run: |
+          nim c -d:release -d:danger --threads:on \
+            -d:BenchLatencyMessageCount=50000 \
+            -d:BenchLatencyRuns=11 \
+            -d:BenchLatencyWarmupRuns=2 \
+            benchmarks/nim/bench_latency.nim
+
+      - name: Run bench_latency
+        # Step-level timeout: latency runs are bounded but a runtime
+        # failure (lost message, missed wakeup) would spin a ponger
+        # thread forever. Fail fast inside the 12-min budget.
+        timeout-minutes: 10
+        run: |
+          ./.tmp/bench_latency --bmf-out=latency.json \
+            sipsic mupmuc sipmuc mupsic | tee latency_output.txt
+
+      - name: Upload latency BMF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-latency-bmf
+          path: latency.json
+
+  bench-upload:
+    # Merges per-binary BMF artifacts into a single JSON before a single
+    # `bencher run` invocation. Bencher creates a separate Report per
+    # invocation; multiple uploads would NOT co-locate measures on a
+    # single per-slug history (design 1 / Track 1 Task 1.4).
+    name: Merge BMF + Bencher upload (ubuntu-latest)
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: [bench-throughput, bench-latency]
+    permissions:
+      pull-requests: write
+      checks: write
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Download BMF artifacts
+        # Pattern matches both bench-throughput-bmf and bench-latency-bmf
+        # (and any future per-binary artifact uploaded by PR 2's topology
+        # split, which uses the same `bench-*-bmf` naming convention).
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bench-*-bmf
+          path: ./bmf-inputs/
+          merge-multiple: true
+
+      - name: List BMF inputs (debug)
+        run: ls -la bmf-inputs/
+
       - name: Merge BMF JSON
-        # Single-input merge today, but the bench-rollup feature splits
-        # bench_throughput into per-topology binaries in PR 2-4 each
-        # producing its own throughput.json fragment. Calling merge_bmf.py
-        # now keeps the workflow unchanged when those fragments arrive.
-        run: python3 benchmarks/merge_bmf.py merged.json throughput.json
+        # `merge_bmf.py` unions per-slug measure dicts across N inputs and
+        # exits 1 on (slug, measure) collisions. Pure stdlib (no third-
+        # party deps), so no Python install step is needed beyond the
+        # ubuntu-latest default.
+        #
+        # `$(ls ...)` is intentionally unquoted: each path must arrive as
+        # a separate positional argv to merge_bmf.py. shellcheck SC2046
+        # flags this as a word-splitting risk; the risk is real ONLY if
+        # an artifact filename contains whitespace or glob characters.
+        # Artifacts are produced by upload-artifact@v4 with names we
+        # control (`throughput.json`, `latency.json`); none contain
+        # whitespace, so the warning does not apply here.
+        run: |
+          # shellcheck disable=SC2046
+          python3 benchmarks/merge_bmf.py merged.json $(ls bmf-inputs/*.json)
 
       - name: Show BMF JSON (debug)
         run: cat merged.json

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -187,11 +187,14 @@ jobs:
           sudo apt-get -qq install -y clang
 
       - name: Clone and install sibling Nim deps (nim-debra, nim-typestates)
+        # Mirrors the bench-throughput job: pin to release tags (not
+        # `main`) for deterministic CI; bump in lockstep with build.yml
+        # and lockfreequeues.nimble's `requires`.
         run: |
           set -e
           cd ..
-          git clone --depth 1 --branch main https://github.com/elijahr/nim-debra.git
-          git clone --depth 1 --branch main https://github.com/elijahr/nim-typestates.git
+          git clone --depth 1 --branch v0.6.0 https://github.com/elijahr/nim-debra.git
+          git clone --depth 1 --branch v0.7.0 https://github.com/elijahr/nim-typestates.git
           (cd nim-typestates && nimble install -y)
           (cd nim-debra && nimble install -y)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `-d:BenchMupmucRuns=N`, `-d:BenchMupmucWarmup=N`,
   `-d:BenchChannelsRuns=N`, `-d:BenchChannelsWarmup=N`. Defaults match
   the prior hard-coded `runs = 10`, so production runs are unchanged.
+- `bench_latency` now emits Bencher Metric Format JSON natively via
+  `--bmf-out=<path>`, mirroring `bench_throughput`'s CLI surface (PR 1).
+  Positional args filter the variants run (`sipsic`, `mupmuc`, `sipmuc`,
+  `mupsic`); without any positional arg, all four bounded lockfreequeues
+  variants run at the 1p1c smoke shape. Emitted slugs:
+  `lockfreequeues_sipsic/spsc/1p1c`,
+  `lockfreequeues_sipmuc/mpmc/1p1c`,
+  `lockfreequeues_mupsic/mpsc/1p1c`,
+  `lockfreequeues_mupmuc/mpmc/1p1c`. Each carries
+  `latency_p50_ns` / `latency_p95_ns` / `latency_p99_ns` measures
+  (`latency_p999_ns` / `latency_max_ns` deferred to PR 6's threshold-
+  gating work). The binary is built on top of
+  `bench_common.runLatencyHarness` and uses per-binary intdefines:
+  `-d:BenchLatencyRuns=N` (default 33), `-d:BenchLatencyMessageCount=N`
+  (default 100_000), `-d:BenchLatencyWarmupRuns=N` (default 3).
+- New `bench-latency` job in `.github/workflows/bench.yml` sibling to
+  `bench-throughput`. Both jobs upload per-binary BMF artifacts
+  (`bench-throughput-bmf` / `bench-latency-bmf`) consumed by a new
+  `bench-upload` job that downloads via `actions/download-artifact@v4`
+  pattern `bench-*-bmf`, runs `merge_bmf.py` to union the fragments,
+  and performs the single `bencher run` upload that co-locates latency
+  + throughput measures on shared per-slug histories. (Multiple
+  `bencher run` invocations create separate Bencher Reports and would
+  NOT co-locate measures — see merge rationale in design 1.)
 
 ### Changed
 
@@ -72,6 +96,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `benchmarks/README.md` rewritten to document the new flow
   (bench_common module, adapter convention, `--bmf-out` flag,
   merge_bmf.py, expected slug set).
+- `benchmarks/nim/adapter.nim` now re-exports `PushResult` / `PopResult`
+  from `bench_common` instead of defining its own copies, unifying the
+  two parallel type definitions introduced by PR 0 Task 0.1. Both
+  adapter packs (legacy `lockfreequeues_sipsic` / `lockfreequeues_mupmuc`
+  / `channels` and the newer `lockfreequeues_sipmuc` / `mupsic` /
+  `unbounded_*`) now flow through the same `runLatencyHarness` and
+  `runThroughputHarness` without per-call-site type conversion. No
+  external API change: legacy callers that imported `./adapter` for
+  `PushResult` / `PopResult` continue to compile (PR 1).
 
 ### Removed
 

--- a/benchmarks/nim/adapter.nim
+++ b/benchmarks/nim/adapter.nim
@@ -1,18 +1,24 @@
 ## Queue adapter interface for benchmarking.
 ## Each queue implementation must provide these operations.
+##
+## PR 1 Task 1.2 — `PushResult` / `PopResult` are now re-exported
+## aliases of the canonical types defined in `bench_common`. PR 0 Task 0.1
+## introduced parallel definitions in bench_common, leaving two nominally
+## distinct enums. With both adapter packs (legacy sipsic / mupmuc /
+## channels and the newer sipmuc / mupsic / unbounded_*) flowing through
+## the same `bench_common.runLatencyHarness` / `runThroughputHarness`,
+## the two-enum split forced cross-conversion at every call site. Aliasing
+## here unifies the surface: `prSuccess` / `prFull` are now equal regardless
+## of which module supplied them, and downstream code keeps working
+## unchanged because the legacy import path still resolves both names.
+
+import ./bench_common
+# Re-export the canonical types/enum members from bench_common. Exporting
+# the enum type re-exports its members; individual enum field exports are
+# rejected by the Nim compiler.
+export bench_common.PushResult, bench_common.PopResult
 
 type
-  PushResult* = enum
-    prSuccess,    ## Item was pushed
-    prFull        ## Queue is full (bounded) or allocation failed
-
-  PopResult*[T] = object
-    case success*: bool
-    of true:
-      value*: T
-    of false:
-      discard
-
   ## Generic queue adapter trait
   QueueAdapter*[T] = concept q
     q.push(T) is PushResult

--- a/benchmarks/nim/adapters/lockfreequeues_mupmuc_adapter.nim
+++ b/benchmarks/nim/adapters/lockfreequeues_mupmuc_adapter.nim
@@ -10,8 +10,7 @@
 
 import options
 import lockfreequeues/mupmuc
-import ../adapter
-from ../bench_common import Topology, tMpmc
+import ../bench_common
 
 const topologiesSupported*: set[Topology] = {tMpmc}
 
@@ -24,7 +23,12 @@ type
 proc initMupmucAdapter*[N: static int, T](): MupmucAdapter[N, T] =
   result.queue = create(Mupmuc[N, 1, 1, T])
   result.queue[] = initMupmuc[N, 1, 1, T]()
-  # Use idx parameter to manually assign producer/consumer for single-threaded use
+  # Use idx parameter to manually assign producer/consumer for single-threaded
+  # use AND for multi-threaded ping-pong (bench_common.runLatencyHarness):
+  # `getProducer(idx = 0)` skips the threadId-based registration path, so the
+  # returned object is safe to call from any thread for the bench's 1P/1C
+  # smoke shape (only one producer/consumer slot exists, and the underlying
+  # Vyukov per-slot CAS protocol is fully concurrent-safe).
   result.producer = result.queue[].getProducer(idx = 0)
   result.consumer = result.queue[].getConsumer(idx = 0)
 
@@ -41,17 +45,14 @@ proc cleanup*[N: static int, T](a: var MupmucAdapter[N, T]) =
   deinitMupmucAdapter(a)
 
 proc push*[N: static int, T](a: var MupmucAdapter[N, T], item: T): PushResult =
-  if a.producer.push(item):
-    prSuccess
-  else:
-    prFull
+  if a.producer.push(item): prSuccess else: prFull
 
 proc pop*[N: static int, T](a: var MupmucAdapter[N, T]): PopResult[T] =
   let item = a.consumer.pop()
   if item.isSome:
-    newPopResult(item.get)
+    PopResult[T](success: true, value: item.get)
   else:
-    emptyPopResult[T]()
+    PopResult[T](success: false)
 
 proc name*[N: static int, T](a: MupmucAdapter[N, T]): string =
   "lockfreequeues/Mupmuc[" & $N & "]"

--- a/benchmarks/nim/adapters/lockfreequeues_sipsic_adapter.nim
+++ b/benchmarks/nim/adapters/lockfreequeues_sipsic_adapter.nim
@@ -19,17 +19,14 @@ proc initSipsicAdapter*[N: static int, T](): SipsicAdapter[N, T] =
   result.queue = initSipsic[N, T]()
 
 proc push*[N: static int, T](a: var SipsicAdapter[N, T], item: T): PushResult =
-  if a.queue.push(item):
-    prSuccess
-  else:
-    prFull
+  if a.queue.push(item): prSuccess else: prFull
 
 proc pop*[N: static int, T](a: var SipsicAdapter[N, T]): PopResult[T] =
   let item = a.queue.pop()
   if item.isSome:
-    newPopResult(item.get)
+    PopResult[T](success: true, value: item.get)
   else:
-    emptyPopResult[T]()
+    PopResult[T](success: false)
 
 proc name*[N: static int, T](a: SipsicAdapter[N, T]): string =
   "lockfreequeues/Sipsic[" & $N & "]"

--- a/benchmarks/nim/bench_latency.nim
+++ b/benchmarks/nim/bench_latency.nim
@@ -133,9 +133,13 @@ proc runVariant(
       )
     else:
       raise newException(ValueError, "unknown variant: " & variant)
+  # p999 / max are printed for operator visibility but NOT emitted to BMF
+  # at this PR (latency_p999_ns / latency_max_ns wire-up is deferred to
+  # PR 6 along with their threshold configuration).
   echo fmt"  p50:  {metrics.p50_ns:.0f} ns"
   echo fmt"  p95:  {metrics.p95_ns:.0f} ns"
   echo fmt"  p99:  {metrics.p99_ns:.0f} ns"
+  echo fmt"  p999: {metrics.p999_ns:.0f} ns"
   echo fmt"  max:  {metrics.max_ns:.0f} ns"
   echo fmt"  samples: {metrics.samples}"
   echo ""

--- a/benchmarks/nim/bench_latency.nim
+++ b/benchmarks/nim/bench_latency.nim
@@ -1,18 +1,54 @@
-
-
 ## Latency benchmark: Ping-pong between 2 threads.
 ## Measures RTT in nanoseconds with percentile distribution.
+##
+## Task 1.1 (PR 1) — exposes per-binary `{.intdefine.}` overrides for
+## wall-time control: `BenchLatencyRuns` (default 33) and
+## `BenchLatencyMessageCount` (default 100_000). These mirror the
+## `BenchSipsicRuns` / `MessageCount` pattern in bench_throughput.nim.
+## They are referenced by Task 1.2 once the binary is rewritten on top
+## of `bench_common.runLatencyHarness`; until then they are public-API
+## stable so downstream test/CI tasks can pin them.
 
 import std/[atomics, times, monotimes]
 import ./stats
 import ./results
 import ./adapter
-import ./adapters/lockfreequeues_sipsic
+import ./adapters/lockfreequeues_sipsic_adapter
 
 const
+  ## Per-binary intdefines for latency wall-time control. Task 1.2 wires
+  ## these into the rewritten `runLatencyHarness` call site; Task 1.1
+  ## only ships the symbols + defaults so the test surface lands first.
+  ## NOTE: kept as `*` (exported) so external consumers (tests, CI) can
+  ## reference them; legacy `DefaultIterations` / `DefaultRuns` /
+  ## `WarmupRuns` remain so the existing `runLatencyBenchmark` path
+  ## continues to compile until Task 1.2 deletes it.
+  BenchLatencyRuns* {.intdefine.} = 33
+  BenchLatencyMessageCount* {.intdefine.} = 100_000
+
   DefaultIterations = 100_000
   DefaultRuns = 33
   WarmupRuns = 3
+
+# Task 1.1 compile-time test gates. These flags are set ONLY by
+# `tests/t_bench_latency.nim` to assert the intdefine defaults / overrides
+# at compile time; production builds never set them, so the `static`
+# blocks evaluate trivially in normal use.
+when defined(BenchLatencyTestCompileTime):
+  static:
+    doAssert BenchLatencyRuns == 33,
+      "BenchLatencyRuns default must be 33 (got " & $BenchLatencyRuns & ")"
+    doAssert BenchLatencyMessageCount == 100_000,
+      "BenchLatencyMessageCount default must be 100_000 (got " &
+      $BenchLatencyMessageCount & ")"
+
+when defined(BenchLatencyTestCompileTimeOverrides):
+  static:
+    doAssert BenchLatencyRuns == 2,
+      "BenchLatencyRuns override must be 2 (got " & $BenchLatencyRuns & ")"
+    doAssert BenchLatencyMessageCount == 1000,
+      "BenchLatencyMessageCount override must be 1000 (got " &
+      $BenchLatencyMessageCount & ")"
 
 type
   PingPongContext[Q] = object

--- a/benchmarks/nim/bench_latency.nim
+++ b/benchmarks/nim/bench_latency.nim
@@ -1,39 +1,45 @@
-## Latency benchmark: Ping-pong between 2 threads.
-## Measures RTT in nanoseconds with percentile distribution.
+## Latency benchmark: ping-pong RTT between 2 threads.
 ##
-## Task 1.1 (PR 1) — exposes per-binary `{.intdefine.}` overrides for
-## wall-time control: `BenchLatencyRuns` (default 33) and
-## `BenchLatencyMessageCount` (default 100_000). These mirror the
-## `BenchSipsicRuns` / `MessageCount` pattern in bench_throughput.nim.
-## They are referenced by Task 1.2 once the binary is rewritten on top
-## of `bench_common.runLatencyHarness`; until then they are public-API
-## stable so downstream test/CI tasks can pin them.
+## Track 1 PR 1 — rewritten on top of `bench_common.runLatencyHarness`.
+## Mirrors the bench_throughput CLI surface:
+##
+##   bench_latency [--bmf-out=<path>] [<variant>...]
+##
+## Positional args filter the variants to run (legacy, preserved); without
+## any positional arg, all four bounded lockfreequeues variants run at the
+## 1p1c smoke shape (`sipsic`, `mupmuc`, `sipmuc`, `mupsic`). `--bmf-out`
+## emits Bencher Metric Format JSON natively. Stdout text is preserved.
+##
+## Per-binary intdefines:
+##   -d:BenchLatencyRuns=<N>            (default 33)
+##   -d:BenchLatencyMessageCount=<N>    (default 100_000)
+##   -d:BenchLatencyWarmupRuns=<N>      (default 3)
+##
+## Emitted measures per slug:
+##   latency_p50_ns, latency_p95_ns, latency_p99_ns
+##   (latency_p999_ns / latency_max_ns are deferred to PR 6.)
+##
+## Slug shape: `<library_slug>/<topology>/1p1c` per design 2.2 / table at
+## design line 357.
 
-import std/[atomics, times, monotimes]
-import ./stats
-import ./results
-import ./adapter
+import std/[options, os, parseopt, sets, strformat, syncio]
+import ./bench_common
 import ./adapters/lockfreequeues_sipsic_adapter
+import ./adapters/lockfreequeues_sipmuc_adapter
+import ./adapters/lockfreequeues_mupsic_adapter
+import ./adapters/lockfreequeues_mupmuc_adapter
 
 const
-  ## Per-binary intdefines for latency wall-time control. Task 1.2 wires
-  ## these into the rewritten `runLatencyHarness` call site; Task 1.1
-  ## only ships the symbols + defaults so the test surface lands first.
-  ## NOTE: kept as `*` (exported) so external consumers (tests, CI) can
-  ## reference them; legacy `DefaultIterations` / `DefaultRuns` /
-  ## `WarmupRuns` remain so the existing `runLatencyBenchmark` path
-  ## continues to compile until Task 1.2 deletes it.
+  ## Per-binary intdefines for latency wall-time control. Mirror the
+  ## `BenchSipsicRuns` / `MessageCount` pattern in bench_throughput.nim.
+  ## Override at compile time with `-d:BenchLatencyRuns=N` etc.
   BenchLatencyRuns* {.intdefine.} = 33
   BenchLatencyMessageCount* {.intdefine.} = 100_000
+  BenchLatencyWarmupRuns* {.intdefine.} = 3
 
-  DefaultIterations = 100_000
-  DefaultRuns = 33
-  WarmupRuns = 3
-
-# Task 1.1 compile-time test gates. These flags are set ONLY by
-# `tests/t_bench_latency.nim` to assert the intdefine defaults / overrides
-# at compile time; production builds never set them, so the `static`
-# blocks evaluate trivially in normal use.
+# Compile-time test gates. These flags are set ONLY by
+# `tests/t_bench_latency.nim` to assert the intdefine defaults / overrides;
+# production builds never set them.
 when defined(BenchLatencyTestCompileTime):
   static:
     doAssert BenchLatencyRuns == 33,
@@ -50,116 +56,144 @@ when defined(BenchLatencyTestCompileTimeOverrides):
       "BenchLatencyMessageCount override must be 1000 (got " &
       $BenchLatencyMessageCount & ")"
 
-type
-  PingPongContext[Q] = object
-    sendQueue: ptr Q
-    recvQueue: ptr Q
-    iterations: int
-    ready: ptr Atomic[bool]
+# ---------- Variant queueInit closures ----------
+#
+# `runLatencyHarness` takes a `proc(): Q` factory. The 4 bounded
+# adapters have non-uniform factory shapes (`initSipsicAdapter`
+# vs `makeLockfreequeuesSipmucAdapter(capacity = N)` etc.) so we
+# wrap each in a uniform `proc(): Adapter` closure. Capacity is
+# pinned to 1024 — same value used by bench_throughput's sipsic
+# slug — to keep latency runs comparable to throughput on the
+# shared 1p1c slug.
 
-proc pongProc[Q](ctx: ptr PingPongContext[Q]) {.thread.} =
-  ctx.ready[].store(true, moRelease)
+const LatencyCapacity = 1024
 
-  for _ in 0..<ctx.iterations:
-    # Wait for ping
-    while true:
-      let item = ctx.recvQueue[].pop()
-      if item.success:
-        break
-    # Send pong
-    while ctx.sendQueue[].push(1) == prFull:
-      discard
+proc initSipsic(): SipsicAdapter[LatencyCapacity, uint64] =
+  initSipsicAdapter[LatencyCapacity, uint64]()
 
-proc runLatencyBenchmark*[Q](
-    initQueue: proc(): Q,
-    iterations: int = DefaultIterations
-): seq[float] =
-  ## Returns array of RTT samples in nanoseconds
-  var sendQ = initQueue()
-  var recvQ = initQueue()
-  var ready: Atomic[bool]
-  ready.store(false)
+proc initSipmuc(): LockfreequeuesSipmucAdapter[LatencyCapacity, 1, uint64] =
+  makeLockfreequeuesSipmucAdapter[LatencyCapacity, 1, uint64](LatencyCapacity)
 
-  var samples = newSeq[float](iterations)
+proc initMupsic(): LockfreequeuesMupsicAdapter[LatencyCapacity, 1, uint64] =
+  makeLockfreequeuesMupsicAdapter[LatencyCapacity, 1, uint64](LatencyCapacity)
 
-  var pongCtx = PingPongContext[Q](
-    sendQueue: addr recvQ,  # Reversed for pong
-    recvQueue: addr sendQ,
-    iterations: iterations,
-    ready: addr ready
-  )
+proc initMupmuc(): MupmucAdapter[LatencyCapacity, uint64] =
+  initMupmucAdapter[LatencyCapacity, uint64]()
 
-  # Start pong thread
-  var pongThread: Thread[ptr PingPongContext[Q]]
-  createThread(pongThread, pongProc[Q], addr pongCtx)
+# ---------- Variant dispatch ----------
 
-  # Wait for pong ready
-  while not ready.load(moAcquire):
-    discard
+const SupportedVariants = ["sipsic", "mupmuc", "sipmuc", "mupsic"]
 
-  for i in 0..<iterations:
-    let startTime = getMonoTime()
+proc slugFor(variant: string): string =
+  ## Slug per design 2.2 / table at design line 357. PR 1 covers the 1p1c
+  ## smoke shape only; PR 2's topology split adds the full grid.
+  case variant
+  of "sipsic": "lockfreequeues_sipsic/spsc/1p1c"
+  of "sipmuc": "lockfreequeues_sipmuc/mpmc/1p1c"
+  of "mupsic": "lockfreequeues_mupsic/mpsc/1p1c"
+  of "mupmuc": "lockfreequeues_mupmuc/mpmc/1p1c"
+  else:
+    raise newException(ValueError, "unknown variant: " & variant)
 
-    # Send ping
-    while sendQ.push(1) == prFull:
-      discard
-    # Wait for pong
-    while true:
-      let item = recvQ.pop()
-      if item.success:
-        break
-
-    let endTime = getMonoTime()
-    samples[i] = float(inNanoseconds(endTime - startTime))
-
-  joinThread(pongThread)
-  samples
-
-proc benchmarkLatency*[Q](
-    initQueue: proc(): Q,
-    iterations: int = DefaultIterations,
-    runs: int = DefaultRuns,
-    warmup: int = WarmupRuns
-): LatencyMetrics =
-  ## Run multiple iterations and collect percentile statistics
-  var allSamples: seq[float] = @[]
-
-  # Warmup
-  for _ in 0..<warmup:
-    discard runLatencyBenchmark(initQueue, iterations div 10)
-
-  # Actual runs - collect all samples
-  for _ in 0..<runs:
-    let samples = runLatencyBenchmark(initQueue, iterations)
-    allSamples.add(samples)
-
-  LatencyMetrics(
-    mean: mean(allSamples),
-    p50: percentile(allSamples, 0.50),
-    p95: percentile(allSamples, 0.95),
-    p99: percentile(allSamples, 0.99),
-    p999: percentile(allSamples, 0.999),
-    min: minVal(allSamples),
-    max: maxVal(allSamples)
-  )
+proc runVariant(
+    variant: string, em: var BMFEmitter
+) =
+  ## Run one variant's latency harness, print stdout, and emit BMF.
+  let slug = slugFor(variant)
+  echo fmt"{variant} ({slug}):"
+  let metrics =
+    case variant
+    of "sipsic":
+      runLatencyHarness[SipsicAdapter[LatencyCapacity, uint64]](
+        queueInit = initSipsic,
+        messageCount = BenchLatencyMessageCount,
+        runCount = BenchLatencyRuns,
+        warmupCount = BenchLatencyWarmupRuns,
+      )
+    of "sipmuc":
+      runLatencyHarness[LockfreequeuesSipmucAdapter[LatencyCapacity, 1, uint64]](
+        queueInit = initSipmuc,
+        messageCount = BenchLatencyMessageCount,
+        runCount = BenchLatencyRuns,
+        warmupCount = BenchLatencyWarmupRuns,
+      )
+    of "mupsic":
+      runLatencyHarness[LockfreequeuesMupsicAdapter[LatencyCapacity, 1, uint64]](
+        queueInit = initMupsic,
+        messageCount = BenchLatencyMessageCount,
+        runCount = BenchLatencyRuns,
+        warmupCount = BenchLatencyWarmupRuns,
+      )
+    of "mupmuc":
+      runLatencyHarness[MupmucAdapter[LatencyCapacity, uint64]](
+        queueInit = initMupmuc,
+        messageCount = BenchLatencyMessageCount,
+        runCount = BenchLatencyRuns,
+        warmupCount = BenchLatencyWarmupRuns,
+      )
+    else:
+      raise newException(ValueError, "unknown variant: " & variant)
+  echo fmt"  p50:  {metrics.p50_ns:.0f} ns"
+  echo fmt"  p95:  {metrics.p95_ns:.0f} ns"
+  echo fmt"  p99:  {metrics.p99_ns:.0f} ns"
+  echo fmt"  max:  {metrics.max_ns:.0f} ns"
+  echo fmt"  samples: {metrics.samples}"
+  echo ""
+  em.addMeasure(slug, "latency_p50_ns", metrics.p50_ns)
+  em.addMeasure(slug, "latency_p95_ns", metrics.p95_ns)
+  em.addMeasure(slug, "latency_p99_ns", metrics.p99_ns)
 
 when isMainModule:
-  import std/strformat
+  # Unbuffer stdout so progress is visible when the bench is run under
+  # a file redirect (mirrors bench_throughput's setStdIoUnbuffered call).
+  setStdIoUnbuffered()
+
+  var bmfOutPath = ""
+  var positional: seq[string] = @[]
+  block parseCli:
+    var p = initOptParser(commandLineParams())
+    while true:
+      p.next()
+      case p.kind
+      of cmdEnd: break
+      of cmdLongOption, cmdShortOption:
+        case p.key
+        of "bmf-out":
+          if p.val.len == 0:
+            echo "Missing value for --bmf-out"
+            quit 1
+          bmfOutPath = p.val
+        else:
+          echo "Unknown flag: --", p.key
+          quit 1
+      of cmdArgument:
+        positional.add(p.key)
+
+  let supported = SupportedVariants.toHashSet
+  let runVariants =
+    if positional.len == 0:
+      supported
+    else:
+      var groups = initHashSet[string]()
+      for arg in positional:
+        if arg notin supported:
+          echo "Unknown variant: ", arg
+          echo "Supported: ", SupportedVariants
+          quit 1
+        groups.incl arg
+      groups
 
   echo "Latency Benchmark (ping-pong RTT)"
-  echo "=================================="
+  echo "================================="
   echo ""
 
-  echo "Sipsic (bounded SPSC):"
-  let metrics = benchmarkLatency(
-    proc(): SipsicAdapter[64, int] = initSipsicAdapter[64, int](),
-    iterations = 10_000,
-    runs = 5
-  )
-  echo fmt"  mean: {metrics.mean:.0f} ns"
-  echo fmt"  p50:  {metrics.p50:.0f} ns"
-  echo fmt"  p95:  {metrics.p95:.0f} ns"
-  echo fmt"  p99:  {metrics.p99:.0f} ns"
-  echo fmt"  p999: {metrics.p999:.0f} ns"
-  echo fmt"  min:  {metrics.min:.0f} ns"
-  echo fmt"  max:  {metrics.max:.0f} ns"
+  var emitter = initBMFEmitter()
+
+  # Iterate in a deterministic order (the SupportedVariants array order)
+  # so stdout is reproducible across runs and grep-friendly in CI logs.
+  for v in SupportedVariants:
+    if v in runVariants:
+      runVariant(v, emitter)
+
+  if bmfOutPath.len > 0:
+    emitter.emit(bmfOutPath)

--- a/benchmarks/nim/bench_latency.nim
+++ b/benchmarks/nim/bench_latency.nim
@@ -164,7 +164,8 @@ when isMainModule:
             quit 1
           bmfOutPath = p.val
         else:
-          echo "Unknown flag: --", p.key
+          let prefix = (if p.kind == cmdLongOption: "--" else: "-")
+          echo "Unknown flag: ", prefix, p.key
           quit 1
       of cmdArgument:
         positional.add(p.key)
@@ -174,14 +175,14 @@ when isMainModule:
     if positional.len == 0:
       supported
     else:
-      var groups = initHashSet[string]()
+      var variants = initHashSet[string]()
       for arg in positional:
         if arg notin supported:
           echo "Unknown variant: ", arg
           echo "Supported: ", SupportedVariants
           quit 1
-        groups.incl arg
-      groups
+        variants.incl arg
+      variants
 
   echo "Latency Benchmark (ping-pong RTT)"
   echo "================================="

--- a/lockfreequeues.nimble
+++ b/lockfreequeues.nimble
@@ -70,6 +70,7 @@ task benchtests, "Runs the bench harness test suite":
   # extend this task with additional `t_bench_*.nim` files as they
   # land.
   exec "nim c --threads:on -r -f tests/t_bench_common.nim"
+  exec "nim c --threads:on -r -f tests/t_bench_latency.nim"
 
 
 task stresstests, "Runs the stress test suite (multi-threaded)":

--- a/tests/t_bench_latency.nim
+++ b/tests/t_bench_latency.nim
@@ -16,6 +16,17 @@ const
   RepoRoot = currentSourcePath().parentDir.parentDir
   BenchLatencySrc = RepoRoot / "benchmarks" / "nim" / "bench_latency.nim"
 
+proc newTestWorkspace(prefix: string): string =
+  ## Allocate a private workspace dir for one test. Each test that
+  ## compiles a bench_latency binary or writes a BMF file uses this so:
+  ##   1. parallel runs (or repeated runs in the same shell) cannot
+  ##      collide on a static `/tmp/bench_latency_t11_*` filename, and
+  ##   2. compiled binaries don't accumulate in the system temp dir.
+  ## The caller is responsible for `removeDir` (typically via `defer`).
+  ## `prefix` is a per-test stem that matches the original static suffix
+  ## so test failure messages stay legible.
+  result = createTempDir("bench_latency_" & prefix & "_", "")
+
 # ---------- Task 1.1: intdefine defaults + override ----------
 
 suite "bench_latency intdefines (Task 1.1)":
@@ -24,7 +35,9 @@ suite "bench_latency intdefines (Task 1.1)":
     # The binary, when this define is set, runs a `static` block that
     # asserts the two intdefine defaults; if they are wrong, compilation
     # fails with the static assert message.
-    let outBin = getTempDir() / "bench_latency_t11_defaults"
+    let dir = newTestWorkspace("t11_defaults")
+    defer: removeDir(dir)
+    let outBin = dir / ("bench_latency" & ExeExt)
     let cmd = "nim c --threads:on -d:release -d:BenchLatencyTestCompileTime=1 " &
               "-o:" & outBin & " " & BenchLatencySrc
     let (output, exitCode) = execCmdEx(cmd)
@@ -35,7 +48,9 @@ suite "bench_latency intdefines (Task 1.1)":
   test "overrides: -d:BenchLatencyRuns=2 -d:BenchLatencyMessageCount=1000 take effect":
     # Compile with overrides + a different test flag that checks the
     # overridden values rather than the defaults.
-    let outBin = getTempDir() / "bench_latency_t11_overrides"
+    let dir = newTestWorkspace("t11_overrides")
+    defer: removeDir(dir)
+    let outBin = dir / ("bench_latency" & ExeExt)
     let cmd = "nim c --threads:on -d:release " &
               "-d:BenchLatencyTestCompileTimeOverrides=1 " &
               "-d:BenchLatencyRuns=2 -d:BenchLatencyMessageCount=1000 " &
@@ -47,11 +62,14 @@ suite "bench_latency intdefines (Task 1.1)":
 
 # ---------- Task 1.2: --bmf-out integration ----------
 
-proc compileBenchLatency(extraDefs: openArray[string], suffix: string): string =
-  ## Compile bench_latency.nim with extra -d: defines, return path to the
-  ## resulting binary. Compiles in release mode for realistic timing but
-  ## with tiny message counts so the integration test stays fast.
-  let outBin = getTempDir() / ("bench_latency_t" & suffix)
+proc compileBenchLatency(
+    extraDefs: openArray[string], dir: string
+): string =
+  ## Compile bench_latency.nim with extra -d: defines into `dir` and
+  ## return the binary path. Caller owns `dir` and must remove it.
+  ## Compiles in release mode for realistic timing but with tiny
+  ## message counts so the integration test stays fast.
+  let outBin = dir / ("bench_latency" & ExeExt)
   var cmd = "nim c --threads:on -d:release"
   for d in extraDefs:
     cmd.add(" -d:" & d)
@@ -64,12 +82,13 @@ proc compileBenchLatency(extraDefs: openArray[string], suffix: string): string =
 suite "bench_latency --bmf-out integration (Task 1.2)":
   test "sipsic variant emits latency_p50_ns / latency_p99_ns on expected slug":
     # Override message count + runs to keep the integration run under ~5s.
+    let dir = newTestWorkspace("t12_sipsic")
+    defer: removeDir(dir)
     let bin = compileBenchLatency(@[
       "BenchLatencyMessageCount=200",
       "BenchLatencyRuns=2",
-    ], suffix = "12_sipsic")
-    let bmfPath = getTempDir() / "bench_latency_t12_sipsic.json"
-    if fileExists(bmfPath): removeFile(bmfPath)
+    ], dir = dir)
+    let bmfPath = dir / "bench_latency.json"
     let cmd = bin & " --bmf-out=" & bmfPath & " sipsic"
     let (output, exitCode) = execCmdEx(cmd)
     check exitCode == 0
@@ -86,18 +105,18 @@ suite "bench_latency --bmf-out integration (Task 1.2)":
     check s["latency_p99_ns"]["value"].getFloat() >= s["latency_p50_ns"]["value"].getFloat()
     # Stdout text output preserved (acceptance: positional CLI behavior).
     check output.contains("Sipsic") or output.contains("sipsic")
-    removeFile(bmfPath)
 
   test "all four bounded variants emit latency_p50_ns / latency_p99_ns":
     # Per impl plan Track 1 Acceptance Criteria: BMF JSON contains
     # latency_p50_ns and latency_p99_ns for sipsic / sipmuc / mupsic /
     # mupmuc on the 1p1c smoke shape.
+    let dir = newTestWorkspace("t12_all4")
+    defer: removeDir(dir)
     let bin = compileBenchLatency(@[
       "BenchLatencyMessageCount=200",
       "BenchLatencyRuns=2",
-    ], suffix = "12_all4")
-    let bmfPath = getTempDir() / "bench_latency_t12_all4.json"
-    if fileExists(bmfPath): removeFile(bmfPath)
+    ], dir = dir)
+    let bmfPath = dir / "bench_latency.json"
     let cmd = bin & " --bmf-out=" & bmfPath &
               " sipsic mupmuc sipmuc mupsic"
     let (_, exitCode) = execCmdEx(cmd)
@@ -113,13 +132,14 @@ suite "bench_latency --bmf-out integration (Task 1.2)":
       check node.hasKey(slug)
       check node[slug].hasKey("latency_p50_ns")
       check node[slug].hasKey("latency_p99_ns")
-    removeFile(bmfPath)
 
   test "unknown variant exits 1":
+    let dir = newTestWorkspace("t12_unknown")
+    defer: removeDir(dir)
     let bin = compileBenchLatency(@[
       "BenchLatencyMessageCount=200",
       "BenchLatencyRuns=2",
-    ], suffix = "12_unknown")
+    ], dir = dir)
     let cmd = bin & " bogus_variant"
     let (_, exitCode) = execCmdEx(cmd)
     check exitCode == 1

--- a/tests/t_bench_latency.nim
+++ b/tests/t_bench_latency.nim
@@ -44,3 +44,82 @@ suite "bench_latency intdefines (Task 1.1)":
     check exitCode == 0
     if exitCode != 0:
       echo "compile output:\n", output
+
+# ---------- Task 1.2: --bmf-out integration ----------
+
+proc compileBenchLatency(extraDefs: openArray[string], suffix: string): string =
+  ## Compile bench_latency.nim with extra -d: defines, return path to the
+  ## resulting binary. Compiles in release mode for realistic timing but
+  ## with tiny message counts so the integration test stays fast.
+  let outBin = getTempDir() / ("bench_latency_t" & suffix)
+  var cmd = "nim c --threads:on -d:release"
+  for d in extraDefs:
+    cmd.add(" -d:" & d)
+  cmd.add(" -o:" & outBin & " " & BenchLatencySrc)
+  let (output, exitCode) = execCmdEx(cmd)
+  if exitCode != 0:
+    raise newException(IOError, "bench_latency compile failed:\n" & output)
+  result = outBin
+
+suite "bench_latency --bmf-out integration (Task 1.2)":
+  test "sipsic variant emits latency_p50_ns / latency_p99_ns on expected slug":
+    # Override message count + runs to keep the integration run under ~5s.
+    let bin = compileBenchLatency(@[
+      "BenchLatencyMessageCount=200",
+      "BenchLatencyRuns=2",
+    ], suffix = "12_sipsic")
+    let bmfPath = getTempDir() / "bench_latency_t12_sipsic.json"
+    if fileExists(bmfPath): removeFile(bmfPath)
+    let cmd = bin & " --bmf-out=" & bmfPath & " sipsic"
+    let (output, exitCode) = execCmdEx(cmd)
+    check exitCode == 0
+    check fileExists(bmfPath)
+    let node = parseJson(readFile(bmfPath))
+    # Expected slug per design 2.2 / table at design line 357.
+    let slug = "lockfreequeues_sipsic/spsc/1p1c"
+    check node.hasKey(slug)
+    let s = node[slug]
+    check s.hasKey("latency_p50_ns")
+    check s.hasKey("latency_p95_ns")
+    check s.hasKey("latency_p99_ns")
+    check s["latency_p50_ns"]["value"].getFloat() > 0.0
+    check s["latency_p99_ns"]["value"].getFloat() >= s["latency_p50_ns"]["value"].getFloat()
+    # Stdout text output preserved (acceptance: positional CLI behavior).
+    check output.contains("Sipsic") or output.contains("sipsic")
+    removeFile(bmfPath)
+
+  test "all four bounded variants emit latency_p50_ns / latency_p99_ns":
+    # Per impl plan Track 1 Acceptance Criteria: BMF JSON contains
+    # latency_p50_ns and latency_p99_ns for sipsic / sipmuc / mupsic /
+    # mupmuc on the 1p1c smoke shape.
+    let bin = compileBenchLatency(@[
+      "BenchLatencyMessageCount=200",
+      "BenchLatencyRuns=2",
+    ], suffix = "12_all4")
+    let bmfPath = getTempDir() / "bench_latency_t12_all4.json"
+    if fileExists(bmfPath): removeFile(bmfPath)
+    let cmd = bin & " --bmf-out=" & bmfPath &
+              " sipsic mupmuc sipmuc mupsic"
+    let (_, exitCode) = execCmdEx(cmd)
+    check exitCode == 0
+    let node = parseJson(readFile(bmfPath))
+    let expectedSlugs = @[
+      "lockfreequeues_sipsic/spsc/1p1c",
+      "lockfreequeues_sipmuc/mpmc/1p1c",
+      "lockfreequeues_mupsic/mpsc/1p1c",
+      "lockfreequeues_mupmuc/mpmc/1p1c",
+    ]
+    for slug in expectedSlugs:
+      check node.hasKey(slug)
+      check node[slug].hasKey("latency_p50_ns")
+      check node[slug].hasKey("latency_p99_ns")
+    removeFile(bmfPath)
+
+  test "unknown variant exits 1":
+    let bin = compileBenchLatency(@[
+      "BenchLatencyMessageCount=200",
+      "BenchLatencyRuns=2",
+    ], suffix = "12_unknown")
+    let cmd = bin & " bogus_variant"
+    let (_, exitCode) = execCmdEx(cmd)
+    check exitCode == 1

--- a/tests/t_bench_latency.nim
+++ b/tests/t_bench_latency.nim
@@ -1,0 +1,46 @@
+## Tests for benchmarks/nim/bench_latency.nim — the latency bench binary.
+##
+## Track 1 (PR 1) covers: per-binary intdefines (Task 1.1), --bmf-out
+## emission via runLatencyHarness (Task 1.2), and multi-measure-per-slug
+## merge with throughput (Task 1.5).
+##
+## The bench binary is invoked as a subprocess in the integration tests
+## (Tasks 1.2 / 1.5); compile-time intdefine assertions (Task 1.1) live
+## in the binary itself behind a `BenchLatencyTestCompileTime` flag and
+## are exercised from a tiny dedicated build invocation here.
+
+import std/[json, os, osproc, strutils, tempfiles]
+import unittest2
+
+const
+  RepoRoot = currentSourcePath().parentDir.parentDir
+  BenchLatencySrc = RepoRoot / "benchmarks" / "nim" / "bench_latency.nim"
+
+# ---------- Task 1.1: intdefine defaults + override ----------
+
+suite "bench_latency intdefines (Task 1.1)":
+  test "defaults: BenchLatencyRuns == 33, BenchLatencyMessageCount == 100_000":
+    # Compile bench_latency.nim with -d:BenchLatencyTestCompileTime=1.
+    # The binary, when this define is set, runs a `static` block that
+    # asserts the two intdefine defaults; if they are wrong, compilation
+    # fails with the static assert message.
+    let outBin = getTempDir() / "bench_latency_t11_defaults"
+    let cmd = "nim c --threads:on -d:release -d:BenchLatencyTestCompileTime=1 " &
+              "-o:" & outBin & " " & BenchLatencySrc
+    let (output, exitCode) = execCmdEx(cmd)
+    check exitCode == 0
+    if exitCode != 0:
+      echo "compile output:\n", output
+
+  test "overrides: -d:BenchLatencyRuns=2 -d:BenchLatencyMessageCount=1000 take effect":
+    # Compile with overrides + a different test flag that checks the
+    # overridden values rather than the defaults.
+    let outBin = getTempDir() / "bench_latency_t11_overrides"
+    let cmd = "nim c --threads:on -d:release " &
+              "-d:BenchLatencyTestCompileTimeOverrides=1 " &
+              "-d:BenchLatencyRuns=2 -d:BenchLatencyMessageCount=1000 " &
+              "-o:" & outBin & " " & BenchLatencySrc
+    let (output, exitCode) = execCmdEx(cmd)
+    check exitCode == 0
+    if exitCode != 0:
+      echo "compile output:\n", output

--- a/tests/t_bench_latency.nim
+++ b/tests/t_bench_latency.nim
@@ -123,3 +123,92 @@ suite "bench_latency --bmf-out integration (Task 1.2)":
     let cmd = bin & " bogus_variant"
     let (_, exitCode) = execCmdEx(cmd)
     check exitCode == 1
+
+# ---------- Task 1.5: multi-measure-per-slug merge ----------
+#
+# Validates the end-to-end shape that Track 1 ships: a single slug
+# carries BOTH `throughput_ops_ms` (from bench_throughput's BMF
+# fragment) and `latency_p50_ns` / `latency_p99_ns` (from bench_latency)
+# AFTER `merge_bmf.py` unions the two fragments. Production CI does this
+# with real bench output; the test uses two synthetic fragments so it
+# stays fast and deterministic.
+
+const MergeBmfPath = RepoRoot / "benchmarks" / "merge_bmf.py"
+
+suite "bench_latency multi-measure-per-slug merge (Task 1.5)":
+  test "merge_bmf.py unions throughput + latency on shared slug":
+    let dir = createTempDir("bench_latency_t15_", "")
+    defer: removeDir(dir)
+    let throughputPath = dir / "throughput.json"
+    let latencyPath = dir / "latency.json"
+    let mergedPath = dir / "merged.json"
+    let slug = "lockfreequeues_sipsic/spsc/1p1c"
+
+    # Synthetic throughput fragment.
+    writeFile(throughputPath,
+      """{
+  "lockfreequeues_sipsic/spsc/1p1c": {
+    "throughput_ops_ms": {
+      "value": 1234.5,
+      "lower_value": 1200.0,
+      "upper_value": 1270.0
+    }
+  }
+}""")
+    # Synthetic latency fragment on the SAME slug, distinct measures.
+    writeFile(latencyPath,
+      """{
+  "lockfreequeues_sipsic/spsc/1p1c": {
+    "latency_p50_ns": { "value": 250.0 },
+    "latency_p99_ns": { "value": 875.0 }
+  }
+}""")
+
+    let cmd = "python3 " & MergeBmfPath & " " & mergedPath &
+              " " & throughputPath & " " & latencyPath
+    let (output, exitCode) = execCmdEx(cmd)
+    check exitCode == 0
+    if exitCode != 0:
+      echo "merge stdout/stderr:\n", output
+    check fileExists(mergedPath)
+
+    let node = parseJson(readFile(mergedPath))
+    check node.hasKey(slug)
+    let s = node[slug]
+    # All three measures from BOTH fragments must coexist on the shared slug.
+    check s.hasKey("throughput_ops_ms")
+    check s.hasKey("latency_p50_ns")
+    check s.hasKey("latency_p99_ns")
+    check s["throughput_ops_ms"]["value"].getFloat() == 1234.5
+    check s["latency_p50_ns"]["value"].getFloat() == 250.0
+    check s["latency_p99_ns"]["value"].getFloat() == 875.0
+
+  test "merge_bmf.py exits 1 on collision when same measure key in both inputs":
+    # Sanity: the per-slug union union semantics are NOT a free-for-all;
+    # ensure the collision guard from PR 0 Task 0.7 still fires when the
+    # latency fragment accidentally re-declares throughput_ops_ms on the
+    # same slug. This guards against silent overwrites that would erase
+    # one of the measures.
+    let dir = createTempDir("bench_latency_t15_collide_", "")
+    defer: removeDir(dir)
+    let aPath = dir / "a.json"
+    let bPath = dir / "b.json"
+    let mergedPath = dir / "merged.json"
+
+    writeFile(aPath,
+      """{
+  "lockfreequeues_sipsic/spsc/1p1c": {
+    "throughput_ops_ms": { "value": 100.0 }
+  }
+}""")
+    writeFile(bPath,
+      """{
+  "lockfreequeues_sipsic/spsc/1p1c": {
+    "throughput_ops_ms": { "value": 200.0 }
+  }
+}""")
+    let cmd = "python3 " & MergeBmfPath & " " & mergedPath &
+              " " & aPath & " " & bPath
+    let (output, exitCode) = execCmdEx(cmd)
+    check exitCode == 1
+    check output.contains("collision")


### PR DESCRIPTION
**Stacked PR — Depends on PR #19** (`feat/bench-rollup-pr0-bench-common`).

PR 1 of the bench-rollup series. Proves multi-measure-per-slug end-to-end by wiring `bench_latency.nim` into the BMF emission pipeline introduced in PR 0, then merging the latency fragment with the throughput fragment in CI before a single `bencher run` upload.

## What changed

- **`benchmarks/nim/bench_latency.nim`** — rewritten on top of `bench_common.runLatencyHarness`. CLI mirrors `bench_throughput`: positional variant filter (`sipsic` / `mupmuc` / `sipmuc` / `mupsic`), `--bmf-out=<path>` for native BMF emission, stdout text preserved. New per-binary intdefines: `BenchLatencyRuns` (default 33), `BenchLatencyMessageCount` (default 100_000), `BenchLatencyWarmupRuns` (default 3).
- **`.github/workflows/bench.yml`** — restructured from one all-in-one job into three:
  - `bench-throughput` (renamed from `benchmark`): builds + runs `bench_throughput`, uploads `bench-throughput-bmf` artifact.
  - `bench-latency` (NEW): builds + runs `bench_latency`, uploads `bench-latency-bmf` artifact. CI-tuned shape: 50K messages × 11 runs × 2 warmup so the four 1p1c smoke variants finish in single-digit seconds inside the 12-min budget.
  - `bench-upload` (NEW, needs both): downloads `bench-*-bmf` artifacts, runs `python3 benchmarks/merge_bmf.py merged.json $(ls bmf-inputs/*.json)`, then runs the existing Bencher CLI upload flows (PR comparison / push baseline / workflow_dispatch). One `bencher run` invocation -> one Bencher Report -> latency + throughput measures co-located on shared per-slug histories (Bencher creates a separate Report per invocation, so multiple uploads would NOT co-locate measures — see merge rationale in design 1).
- **`benchmarks/nim/adapter.nim`** — re-exports `PushResult` / `PopResult` from `bench_common` instead of defining its own copies, unifying the two parallel definitions introduced by PR 0 Task 0.1. Both adapter packs (legacy `lockfreequeues_sipsic` / `mupmuc` / `channels` and the newer `lockfreequeues_sipmuc` / `mupsic` / `unbounded_*`) now flow through the same harnesses without per-call-site type conversion.
- **`benchmarks/nim/adapters/lockfreequeues_sipsic_adapter.nim`** and **`lockfreequeues_mupmuc_adapter.nim`** — drop `newPopResult` / `emptyPopResult` constructors in favor of the plain `PopResult[T]` literal form (compatible with the unified non-case-object type). Mupmuc adapter doc clarifies that `getProducer(idx = 0)` / `getConsumer(idx = 0)` bypasses Mupmuc's threadId-based registration, so the pre-built producer / consumer slots are safe to drive from either of the harness's pinger and ponger threads (Mupmuc's underlying Vyukov per-slot CAS protocol is fully concurrent-safe).
- **`tests/t_bench_latency.nim`** (NEW) — 7 tests across three suites:
  - Task 1.1: intdefine defaults + override compile-time assertions (2 tests).
  - Task 1.2: `--bmf-out` integration on sipsic single-variant + four-variant slug coverage + unknown-variant exit-1 (3 tests).
  - Task 1.5: synthetic throughput + latency fragment merge + collision-guard regression (2 tests).
- **`CHANGELOG.md`** — bullets under `[Unreleased]` -> Added (bench_latency native BMF, bench-latency CI job) and Changed (adapter type unification).

## Emitted measures (this PR)

Each of the 4 smoke-shape slugs carries `latency_p50_ns`, `latency_p95_ns`, `latency_p99_ns`:

- `lockfreequeues_sipsic/spsc/1p1c`
- `lockfreequeues_sipmuc/mpmc/1p1c`
- `lockfreequeues_mupsic/mpsc/1p1c`
- `lockfreequeues_mupmuc/mpmc/1p1c`

`latency_p999_ns` / `latency_max_ns` are deferred to PR 6's threshold-gating work, per the impl plan.

## Verification

- `nim c -r tests/test.nim` — 188 core tests pass, 0 failures (no regression).
- `nim c -r tests/t_bench_common.nim` — 26 tests pass (PR 0 surface unchanged).
- `nim c -r tests/t_bench_latency.nim` — 7 tests pass (new).
- `actionlint .github/workflows/bench.yml` — clean.
- Local smoke: `bench_latency --bmf-out=lat.json sipsic mupmuc sipmuc mupsic` produces all 4 slugs with all 3 measures, p50 < p95 < p99 < max.

## Follow-ups (not in this PR)

- **Task 1.6 (Bencher dashboard verification)** — manual step from the impl plan; the screenshot lands in this PR description after CI green and the maintainer's Bencher dashboard inspection.
- **`--threshold-measure throughput`** — preserved as-is in the push-baseline Bencher invocation; the BMF emission renamed the measure to `throughput_ops_ms` in PR 0 Task 0.10, and PR 6 (Task 6.2) reworks the threshold blocks per measure. Out of scope for PR 1.
- **`benchmarks/nim/tests/t_adapter_*.nim`** — orphaned per-adapter unit tests still reference the pre-PR-0-Task-0.9 adapter filenames (`lockfreequeues_sipsic` instead of `lockfreequeues_sipsic_adapter`). Not wired into any CI / nimble task; pre-existing breakage. Will tidy in a later PR.
- **bench_common adapter cleanup hook** — `runOneLatencyRun` / `runOneThroughputRun` don't call adapter `cleanup` / `deinit*`, leaking ~2 small heap allocations per run × 36 runs × 4 variants for the latency path. Bounded and acceptable for the 1p1c smoke shape, but PR 2's topology split should add a generic teardown hook.

## References

- Design doc: `/Users/eek/.local/spellbook/docs/Users-eek-Development-lockfreequeues/plans/2026-05-01-bench-rollup-design.md` section 3 PR 1.
- Implementation plan: `/Users/eek/.local/spellbook/docs/Users-eek-Development-lockfreequeues/plans/2026-05-01-bench-rollup-impl.md` Track 1 (Tasks 1.1-1.7).