### PR TITLE
Comparison MVP: Loony, Boost.LockFree, Crossbeam adapters + cache-line padding fix

### DIFF
--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -34,6 +34,17 @@ jobs:
     # workflow's separate Bencher report.
     name: bench-crossbeam (ubuntu-latest)
     runs-on: ubuntu-latest
+    # Mirror bench.yml's bench-upload permissions: bencher run uses
+    # `--github-actions ${{ secrets.GITHUB_TOKEN }}` to publish check
+    # runs / PR annotations, which require explicit `checks: write` and
+    # `pull-requests: write` on repos with default read-only token
+    # permissions. `contents: read` and `actions: read` cover
+    # actions/checkout and any future artifact downloads.
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+      checks: write
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -63,12 +63,14 @@ jobs:
 
       - name: Clone and install sibling Nim deps (nim-debra, nim-typestates)
         # Mirrors bench.yml -- nim.cfg in src/ resolves these via
-        # ../nim-debra/src and ../nim-typestates/src.
+        # ../nim-debra/src and ../nim-typestates/src. Pin to release
+        # tags (not `main`) for deterministic CI; bump in lockstep with
+        # build.yml/bench.yml and lockfreequeues.nimble's `requires`.
         run: |
           set -e
           cd ..
-          git clone --depth 1 --branch main https://github.com/elijahr/nim-debra.git
-          git clone --depth 1 --branch main https://github.com/elijahr/nim-typestates.git
+          git clone --depth 1 --branch v0.6.0 https://github.com/elijahr/nim-debra.git
+          git clone --depth 1 --branch v0.7.0 https://github.com/elijahr/nim-typestates.git
           (cd nim-typestates && nimble install -y)
           (cd nim-debra && nimble install -y)
 

--- a/.github/workflows/bench-comparison.yml
+++ b/.github/workflows/bench-comparison.yml
@@ -1,0 +1,214 @@
+# yamllint disable rule:line-length
+
+name: bench-comparison
+
+# yamllint disable rule:truthy
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly at 04:00 UTC. Off-peak so the runner pool is fresh; the
+    # cdylib build adds ~30s vs the in-tree benches.
+    - cron: '0 4 * * *'
+  push:
+    branches: [devel]
+    paths:
+      - 'benchmarks/rust/**'
+      - 'benchmarks/nim/adapters/crossbeam_*'
+      - '.github/workflows/bench-comparison.yml'
+# yamllint enable rule:truthy
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench-crossbeam:
+    # Track 3 §3.13: Crossbeam-only comparison workflow.
+    #
+    # Crossbeam adds a Rust toolchain dependency (~5 min cold install),
+    # which would inflate the bench.yml critical path on every PR. Per
+    # design 2.6 / impl plan 3.13 it lives in this dedicated workflow,
+    # gated on nightly cron + workflow_dispatch + targeted path pushes
+    # to devel only. PR check feedback for crossbeam comes from this
+    # workflow's separate Bencher report.
+    name: bench-crossbeam (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Setup Nim
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: 'stable'
+
+      - name: Install build deps (Linux)
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get -qq install -y clang
+
+      - name: Clone and install sibling Nim deps (nim-debra, nim-typestates)
+        # Mirrors bench.yml -- nim.cfg in src/ resolves these via
+        # ../nim-debra/src and ../nim-typestates/src.
+        run: |
+          set -e
+          cd ..
+          git clone --depth 1 --branch main https://github.com/elijahr/nim-debra.git
+          git clone --depth 1 --branch main https://github.com/elijahr/nim-typestates.git
+          (cd nim-typestates && nimble install -y)
+          (cd nim-debra && nimble install -y)
+
+      - name: Vendor unittest2
+        run: git clone --depth 1 https://github.com/status-im/nim-unittest2.git deps/unittest2
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: benchmarks/rust/bench-ffi-crossbeam
+
+      - name: Build crossbeam cdylib
+        # Produces target/release/libbench_ffi_crossbeam.so on Linux.
+        # The Nim adapters' default {.passL.} includes -L for this path
+        # so no further wiring is needed.
+        run: |
+          cargo build --release \
+            --manifest-path benchmarks/rust/bench-ffi-crossbeam/Cargo.toml
+
+      - name: Run cdylib integration tests
+        # Sanity-check the C-ABI surface before paying for the bench
+        # compile. Runs in <1s; fails the workflow on regression.
+        run: |
+          cargo test --release \
+            --manifest-path benchmarks/rust/bench-ffi-crossbeam/Cargo.toml
+
+      - name: Smoke crossbeam adapters
+        # Compile-and-run sanity check that the adapters can resolve the
+        # cdylib symbols at runtime before we spend ~10 min on bench
+        # binaries with the same defines.
+        run: |
+          set -eu
+          nim c -d:release -d:danger --threads:on \
+            -d:adapter_crossbeam_array_queue_available \
+            -d:adapter_crossbeam_seg_queue_available \
+            --passL:"-Wl,-rpath,$(pwd)/benchmarks/rust/bench-ffi-crossbeam/target/release" \
+            -o:.tmp/smoke_crossbeam \
+            benchmarks/nim/smoke/smoke_crossbeam.nim
+          ./.tmp/smoke_crossbeam
+
+      - name: Compile bench_mpmc with crossbeam_array_queue
+        # CI run shape mirrors bench.yml's bench_mpmc settings (1M / 5 / 2).
+        # rpath ensures the dylib loads from the in-tree build dir at
+        # runtime without needing LD_LIBRARY_PATH.
+        run: |
+          set -eu
+          nim c -d:release -d:danger --threads:on \
+            -d:BenchMpmcMessageCount=1000000 \
+            -d:BenchMpmcRuns=5 \
+            -d:BenchMpmcWarmup=2 \
+            -d:adapter_crossbeam_array_queue_available \
+            --passL:"-Wl,-rpath,$(pwd)/benchmarks/rust/bench-ffi-crossbeam/target/release" \
+            benchmarks/nim/bench_mpmc.nim
+
+      - name: Compile bench_unbounded with crossbeam_seg_queue
+        run: |
+          set -eu
+          nim c -d:release -d:danger --threads:on \
+            -d:UnboundedSipsicMessageCount=500000 \
+            -d:UnboundedSipsicRuns=3 \
+            -d:UnboundedSipmucMessageCount=500000 \
+            -d:UnboundedSipmucRuns=3 \
+            -d:UnboundedMupsicMessageCount=500000 \
+            -d:UnboundedMupsicRuns=3 \
+            -d:UnboundedMupmucMessageCount=500000 \
+            -d:UnboundedMupmucRuns=3 \
+            -d:BenchUnboundedWarmup=2 \
+            -d:adapter_crossbeam_seg_queue_available \
+            --passL:"-Wl,-rpath,$(pwd)/benchmarks/rust/bench-ffi-crossbeam/target/release" \
+            benchmarks/nim/bench_unbounded.nim
+
+      - name: Run bench_mpmc (crossbeam_array_queue only)
+        timeout-minutes: 12
+        run: |
+          ./.tmp/bench_mpmc crossbeam_array_queue \
+            --bmf-out=bench_mpmc_crossbeam.json \
+            | tee bench_mpmc_crossbeam_output.txt
+
+      - name: Run bench_unbounded (crossbeam_seg_queue only)
+        timeout-minutes: 12
+        run: |
+          ./.tmp/bench_unbounded crossbeam_seg_queue \
+            --bmf-out=bench_unbounded_crossbeam.json \
+            | tee bench_unbounded_crossbeam_output.txt
+
+      - name: Merge BMF JSON
+        run: |
+          python3 benchmarks/merge_bmf.py merged.json \
+            bench_mpmc_crossbeam.json \
+            bench_unbounded_crossbeam.json
+
+      - name: Show BMF JSON (debug)
+        run: cat merged.json
+
+      - name: Upload BMF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-comparison-crossbeam-bmf
+          path: merged.json
+
+      - name: Install Bencher CLI
+        uses: bencherdev/bencher@main
+
+      - name: Bencher token preflight
+        run: |
+          if [ -z "$BENCHER_API_TOKEN" ]; then
+            echo "::warning title=Bencher upload skipped::BENCHER_API_TOKEN is not set; bench-comparison ran but did not upload."
+          else
+            echo "Bencher token present; proceeding with upload."
+          fi
+
+      - name: Track scheduled benchmarks with Bencher
+        if: github.event_name == 'schedule' && env.BENCHER_API_TOKEN != ''
+        run: |
+          bencher run \
+            --project lockfreequeues \
+            --token '${{ secrets.BENCHER_API_TOKEN }}' \
+            --branch devel \
+            --testbed ubuntu-latest \
+            --threshold-measure throughput \
+            --threshold-test t_test \
+            --threshold-max-sample-size 64 \
+            --threshold-lower-boundary 0.99 \
+            --thresholds-reset \
+            --adapter json \
+            --file merged.json \
+            --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+            --err
+
+      - name: Track devel-push benchmarks with Bencher
+        if: github.event_name == 'push' && env.BENCHER_API_TOKEN != ''
+        run: |
+          bencher run \
+            --project lockfreequeues \
+            --token '${{ secrets.BENCHER_API_TOKEN }}' \
+            --branch devel \
+            --testbed ubuntu-latest \
+            --adapter json \
+            --file merged.json \
+            --github-actions '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Track manual benchmarks with Bencher
+        if: github.event_name == 'workflow_dispatch' && env.BENCHER_API_TOKEN != ''
+        run: |
+          bencher run \
+            --project lockfreequeues \
+            --token '${{ secrets.BENCHER_API_TOKEN }}' \
+            --branch "${GITHUB_REF##*/}" \
+            --testbed ubuntu-latest \
+            --adapter json \
+            --file merged.json

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -21,6 +21,15 @@ on:
       - '*.md'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
+    inputs:
+      force_skip_boost:
+        description: 'Force boost soft-skip (Track 3 §2.6 acceptance)'
+        type: boolean
+        default: false
+      force_skip_loony:
+        description: 'Force loony soft-skip (Track 3 §2.6 acceptance)'
+        type: boolean
+        default: false
 # yamllint enable rule:truthy
 
 env:
@@ -29,6 +38,11 @@ env:
   # presence via `env.BENCHER_API_TOKEN`. GitHub Actions does not allow
   # `secrets.*` directly in `if:`, so the env-var indirection is required.
   BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+  # Track 3 §2.6 soft-skip overrides. Empty string when the
+  # workflow_dispatch input is unset (the default), '1' when the
+  # operator forces a skip. Step-level `if:` clauses gate on these.
+  FORCE_SKIP_BOOST: ${{ inputs.force_skip_boost && '1' || '' }}
+  FORCE_SKIP_LOONY: ${{ inputs.force_skip_loony && '1' || '' }}
 
 jobs:
   bench-tests:
@@ -137,6 +151,135 @@ jobs:
       - name: Vendor unittest2
         run: git clone --depth 1 https://github.com/status-im/nim-unittest2.git deps/unittest2
 
+      # ---------- Track 3 MVP adapter installs (soft-skip) ----------
+      #
+      # Each adapter has three stages: install -> smoke -> set-env-on-success.
+      # Failure at any stage flips the binary's compile flags so the slugs
+      # are simply omitted from the BMF instead of failing the workflow.
+      # Annotate-skipped steps surface a yellow PR-check warning.
+
+      - name: Install boost (libboost-dev for Boost.LockFree)
+        # Boost.LockFree is C++ header-only; libboost-dev pulls the
+        # entire boost include tree on the runner. Skip on bench_mpsc /
+        # bench_unbounded / bench_latency (no boost adapter wired into
+        # those binaries; install would just slow them down).
+        id: install-boost
+        if: |
+          env.FORCE_SKIP_BOOST != '1' &&
+          (matrix.binary == 'bench_spsc' || matrix.binary == 'bench_mpmc')
+        continue-on-error: true
+        run: |
+          sudo apt-get install -qq -y libboost-dev
+
+      - name: Smoke boost adapters
+        id: smoke-boost
+        if: |
+          env.FORCE_SKIP_BOOST != '1' &&
+          steps.install-boost.outcome == 'success' &&
+          (matrix.binary == 'bench_spsc' || matrix.binary == 'bench_mpmc')
+        continue-on-error: true
+        run: |
+          set -eu
+          # Compile and run the smoke binary with both gates so a single
+          # invocation covers queue + spsc_queue. nim cpp because boost
+          # headers are C++.
+          nim cpp -d:release -d:danger --threads:on \
+            -d:adapter_boost_lockfree_queue_available \
+            -d:adapter_boost_lockfree_spsc_available \
+            -o:.tmp/smoke_boost \
+            benchmarks/nim/smoke/smoke_boost.nim
+          ./.tmp/smoke_boost
+
+      - name: Set boost adapter defines (success only)
+        if: |
+          env.FORCE_SKIP_BOOST != '1' &&
+          steps.install-boost.outcome == 'success' &&
+          steps.smoke-boost.outcome == 'success'
+        run: |
+          {
+            echo "ADAPTER_BOOST_QUEUE=1"
+            echo "ADAPTER_BOOST_SPSC=1"
+          } >> "$GITHUB_ENV"
+
+      - name: Annotate boost skipped
+        if: |
+          (matrix.binary == 'bench_spsc' || matrix.binary == 'bench_mpmc') &&
+          (env.FORCE_SKIP_BOOST == '1' ||
+           steps.install-boost.outcome != 'success' ||
+           steps.smoke-boost.outcome != 'success')
+        run: |
+          echo "::warning title=Adapter skipped::boost.lockfree install or smoke failed for ${{ matrix.binary }}; bench will omit boost slugs."
+
+      - name: Install loony (nimble)
+        # Loony is a Nim-only unbounded MPMC queue; nimble pulls it from
+        # the registry. Only bench_unbounded uses it.
+        id: install-loony
+        if: |
+          env.FORCE_SKIP_LOONY != '1' &&
+          matrix.binary == 'bench_unbounded'
+        continue-on-error: true
+        run: |
+          nimble install -y loony
+
+      - name: Smoke loony adapter
+        id: smoke-loony
+        if: |
+          env.FORCE_SKIP_LOONY != '1' &&
+          steps.install-loony.outcome == 'success' &&
+          matrix.binary == 'bench_unbounded'
+        continue-on-error: true
+        run: |
+          # The smoke is the round-trip test in tests/t_bench_adapters.nim.
+          # Compile-only; runs in <1s.
+          set -eu
+          nim c -d:release -d:danger --threads:on \
+            -d:adapter_loony_available \
+            -o:.tmp/smoke_loony \
+            -r tests/t_bench_adapters.nim
+
+      - name: Set loony adapter define (success only)
+        if: |
+          env.FORCE_SKIP_LOONY != '1' &&
+          steps.install-loony.outcome == 'success' &&
+          steps.smoke-loony.outcome == 'success'
+        run: echo "ADAPTER_LOONY=1" >> "$GITHUB_ENV"
+
+      - name: Annotate loony skipped
+        if: |
+          matrix.binary == 'bench_unbounded' &&
+          (env.FORCE_SKIP_LOONY == '1' ||
+           steps.install-loony.outcome != 'success' ||
+           steps.smoke-loony.outcome != 'success')
+        run: |
+          echo "::warning title=Adapter skipped::loony install or smoke failed; bench will omit loony slugs."
+
+      - name: Build adapter define flags
+        # Aggregates the per-adapter env flags into a single shell
+        # variable consumed by the compile step. Empty when no adapter
+        # is enabled; properly space-separated otherwise.
+        id: adapter-flags
+        run: |
+          set -eu
+          flags=""
+          mode="c"
+          if [ "${ADAPTER_BOOST_QUEUE:-}" = "1" ]; then
+            flags="$flags -d:adapter_boost_lockfree_queue_available"
+            mode="cpp"
+          fi
+          if [ "${ADAPTER_BOOST_SPSC:-}" = "1" ]; then
+            flags="$flags -d:adapter_boost_lockfree_spsc_available"
+            mode="cpp"
+          fi
+          if [ "${ADAPTER_LOONY:-}" = "1" ]; then
+            flags="$flags -d:adapter_loony_available"
+          fi
+          {
+            echo "flags=$flags"
+            echo "mode=$mode"
+          } >> "$GITHUB_OUTPUT"
+          echo "Adapter flags: $flags"
+          echo "Compile mode:  $mode"
+
       - name: Compile ${{ matrix.binary }} (CI-tuned run shape)
         # Per-binary -d: overrides mirror the design 2.5 CI override
         # column. Bounded throughput binaries: 1M messages × 5 runs ×
@@ -149,17 +292,29 @@ jobs:
         # keeps PR 1's tighter shape (50K × 11 × 2) because each
         # ping-pong RTT records exactly one sample, so 1M messages
         # would never fit.
+        #
+        # ${{ steps.adapter-flags.outputs.flags }} is the space-separated
+        # set of -d:adapter_*_available defines that survived install +
+        # smoke. ${{ steps.adapter-flags.outputs.mode }} is 'cpp' iff at
+        # least one C++-only adapter (boost) is enabled, else 'c'.
+        env:
+          NIM_MODE: ${{ steps.adapter-flags.outputs.mode }}
+          ADAPTER_FLAGS: ${{ steps.adapter-flags.outputs.flags }}
         run: |
           set -eu
+          # shellcheck disable=SC2086  # ADAPTER_FLAGS is intentionally word-split.
           case "${{ matrix.binary }}" in
             bench_spsc)
-              nim c -d:release -d:danger --threads:on \
+              nim "$NIM_MODE" -d:release -d:danger --threads:on \
                 -d:BenchSpscMessageCount=1000000 \
                 -d:BenchSpscRuns=5 \
                 -d:BenchSpscWarmup=2 \
+                $ADAPTER_FLAGS \
                 benchmarks/nim/bench_spsc.nim
               ;;
             bench_mpsc)
+              # bench_mpsc has no MVP adapter wiring; ignore ADAPTER_FLAGS
+              # / NIM_MODE and stay on `nim c`.
               nim c -d:release -d:danger --threads:on \
                 -d:BenchMpscMessageCount=1000000 \
                 -d:BenchMpscRuns=5 \
@@ -167,13 +322,16 @@ jobs:
                 benchmarks/nim/bench_mpsc.nim
               ;;
             bench_mpmc)
-              nim c -d:release -d:danger --threads:on \
+              nim "$NIM_MODE" -d:release -d:danger --threads:on \
                 -d:BenchMpmcMessageCount=1000000 \
                 -d:BenchMpmcRuns=5 \
                 -d:BenchMpmcWarmup=2 \
+                $ADAPTER_FLAGS \
                 benchmarks/nim/bench_mpmc.nim
               ;;
             bench_unbounded)
+              # bench_unbounded supports loony (Nim, plain `nim c`) but
+              # no boost. Stay on c regardless of NIM_MODE.
               nim c -d:release -d:danger --threads:on \
                 -d:UnboundedSipsicMessageCount=200000 \
                 -d:UnboundedSipsicRuns=3 \
@@ -185,6 +343,7 @@ jobs:
                 -d:UnboundedMupmucRuns=2 \
                 -d:BenchUnboundedWarmup=1 \
                 -d:BenchSkipOversubscribed \
+                $ADAPTER_FLAGS \
                 benchmarks/nim/bench_unbounded.nim
               ;;
             bench_latency)

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ benchmarks/nim/tests/t_*
 # Compiled stress-test binaries (extensionless executables)
 stress-tests/[a-z_]*
 !stress-tests/*.nim
+
+# Rust crate build artifacts (FFI bench bridges)
+benchmarks/rust/*/target/
+benchmarks/rust/*/Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   topology binary) merged via `merge_bmf.py` produce a single output
   whose slug set is the disjoint union, with shared slugs carrying
   measures from every input binary.
+- Five third-party comparison adapters land in `benchmarks/nim/adapters/`
+  for the comparison MVP (PR 3, Track 3): `loony_adapter.nim`
+  (LoonyQueue, MIT, mpmc_unbounded), `boost_lockfree_queue_adapter.nim`
+  (`boost::lockfree::queue`, BSL-1.0, mpmc bounded),
+  `boost_lockfree_spsc_adapter.nim`
+  (`boost::lockfree::spsc_queue`, BSL-1.0, spsc bounded),
+  `crossbeam_array_queue_adapter.nim` (`crossbeam_queue::ArrayQueue`,
+  Apache-2.0 OR MIT, mpmc bounded), `crossbeam_seg_queue_adapter.nim`
+  (`crossbeam_queue::SegQueue`, Apache-2.0 OR MIT, mpmc_unbounded).
+  Each is gated behind a `-d:adapter_<library_slug>_available` define;
+  absent gates produce no symbol references and the production builds
+  are unchanged. Tests in `tests/t_bench_adapters.nim` cover a
+  1000-item push/pop round-trip per adapter.
+- New Rust crate `benchmarks/rust/bench-ffi-crossbeam/`: a `cdylib`
+  exposing 8 `extern "C"` fns (`cb_array_init/push/pop/destroy`,
+  `cb_seg_init/push/pop/destroy`) consumed by the Crossbeam Nim
+  adapters. Pinned via `rust-toolchain.toml` to `stable`. Six
+  integration tests cover round-trip set equality for both queue
+  types, capacity edges, empty-pop, and null-pointer tolerance.
+- New `benchmarks/nim/smoke/` directory with `smoke_boost.nim` and
+  `smoke_crossbeam.nim`: 32-item push/pop round-trip binaries used as
+  fast pre-flight checks in CI before the full bench compile.
+- New workflow `.github/workflows/bench-comparison.yml`: dedicated
+  Crossbeam comparison job triggered by nightly cron (`0 4 * * *`),
+  `workflow_dispatch`, and targeted path pushes to `devel` (anything
+  under `benchmarks/rust/**` or `benchmarks/nim/adapters/crossbeam_*`).
+  Builds the cdylib via `dtolnay/rust-toolchain@stable` +
+  `Swatinem/rust-cache@v2`, runs the cdylib integration tests,
+  compiles `bench_mpmc` + `bench_unbounded` with the crossbeam gates,
+  merges via `merge_bmf.py`, and uploads to a separate Bencher Report.
+  Crossbeam is intentionally NOT in `bench.yml` so PR critical-path
+  time stays unchanged.
+- `bench.yml` gains the `force_skip_boost` / `force_skip_loony`
+  `workflow_dispatch` boolean inputs and a per-library install ->
+  smoke -> set-flag pipeline (design §2.6 soft-skip). Failure at
+  install or smoke flips the binary's compile flags so the slugs are
+  omitted from the BMF instead of failing the workflow; the
+  `Annotate skipped` step emits a `::warning title=Adapter
+  skipped::...` annotation visible on the PR check summary.
+- New `THIRD_PARTY_LICENSES.md` records license obligations for the
+  comparison MVP libraries (Loony MIT, Boost BSL-1.0, Crossbeam
+  Apache-2.0 OR MIT) and reserves placeholder entries for
+  concurrentqueue (PR 4) and uPlot (PR 5).
+- New `src/lockfreequeues/internal/aligned_alloc.nim` exporting
+  `allocAligned[T]: ptr T` via a local `posix_memalign` shim. Used by
+  the four unbounded queue variants to allocate cache-line-aligned
+  segments (64-byte alignment instead of `c_calloc`'s 16-byte ABI
+  guarantee), eliminating the false-sharing asymmetry vs other
+  libraries flagged in design §4.2.
+
+### Fixed
+
+- Cache-line padding for unbounded queue segments. Each `Segment` field
+  participating in producer/consumer coordination now carries
+  `{.align: CacheLineBytes.}`, and the four unbounded variants
+  (`unbounded_sipsic`, `unbounded_sipmuc`, `unbounded_mupsic`,
+  `unbounded_mupmuc`) allocate via `allocAligned[Segment[S, T]]()`
+  instead of `c_calloc`. Verified by `tests/t_unbounded_padding.nim`
+  (8 assertions across 4 variants, green under c/cpp/arc/refc).
 
 ### Changed
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,80 @@
+# Third-Party Licenses
+
+`lockfreequeues` itself is licensed under Apache-2.0 (see `LICENSE`).
+The benchmark suite (under `benchmarks/`) compares `lockfreequeues`
+against several upstream queue libraries; this file records the license
+obligations for each one.
+
+This file is the canonical home for vendored / linked third-party code
+notices. Per [`benchmarks/README.md`](benchmarks/README.md), each entry
+records source, version, license, vendored path (if any), and upgrade
+procedure (if any).
+
+Per-vendor block schema:
+
+```markdown
+### <Library Name>
+
+- **Source:** https://github.com/<owner>/<repo>
+- **Version:** commit `<sha>` (vendored sources) or `<x.y.z>` (tagged releases)
+- **License:** <SPDX identifier>
+- **Vendored at:** `<repo-relative path>` (omit if not vendored)
+- **Upgrade procedure:** see `<repo-relative path>/README.md` (omit if not vendored)
+```
+
+## Comparison MVP libraries (PR 3)
+
+The libraries below are linked at compile time by the bench suite when
+the relevant `-d:adapter_*_available` gate is set; their source is NOT
+vendored into this repository. The benchmark adapter code (under
+`benchmarks/nim/adapters/<lib>_adapter.nim`) is original
+`lockfreequeues` source and inherits the project's Apache-2.0 license.
+
+### Loony
+
+- **Source:** https://github.com/shayanhabibi/loony
+- **Version:** `0.3.1` (resolved by `nimble install loony`; see
+  `nimble.lock` if pinned by a downstream consumer)
+- **License:** MIT
+- **Vendored at:** _(not vendored — resolved at build time via Nimble)_
+- **Upgrade procedure:** _(not applicable; nimble-managed)_
+
+### Boost.LockFree
+
+- **Source:** https://www.boost.org/libs/lockfree/
+- **Version:** Whichever version is provided by the system package
+  (`apt install libboost-dev` on Ubuntu CI; `brew install boost` on
+  macOS dev). The bench adapter is API-compatible with all Boost
+  versions that ship `boost/lockfree/queue.hpp` and
+  `boost/lockfree/spsc_queue.hpp`.
+- **License:** Boost Software License 1.0 (BSL-1.0)
+- **Vendored at:** _(not vendored — system include path)_
+- **Upgrade procedure:** _(not applicable; OS-package-managed)_
+
+### Crossbeam
+
+- **Source:** https://github.com/crossbeam-rs/crossbeam
+- **Version:** `crossbeam-queue 0.3.x` (pinned by
+  `benchmarks/rust/bench-ffi-crossbeam/Cargo.toml`; recorded in the
+  generated `Cargo.lock` at build time)
+- **License:** Apache-2.0 OR MIT (choose either)
+- **Vendored at:** _(crate sources are downloaded by Cargo at build
+  time; only our own thin C-ABI shim under
+  `benchmarks/rust/bench-ffi-crossbeam/` is committed)_
+- **Upgrade procedure:** bump the `crossbeam-queue` version in
+  `benchmarks/rust/bench-ffi-crossbeam/Cargo.toml`, run `cargo build`
+  to refresh `Cargo.lock`, run the integration tests
+  (`cargo test --release --manifest-path benchmarks/rust/bench-ffi-crossbeam/Cargo.toml`)
+  and the Nim round-trip suite (`tests/t_bench_adapters.nim` with the
+  crossbeam gates).
+
+## Future entries (PR 4 / PR 5)
+
+The following libraries are reserved for future PRs in the bench-rollup
+series; entries will be added when their adapters land:
+
+- **concurrentqueue (MoodyCamel)** — vendored under
+  `benchmarks/vendor/concurrentqueue/`, BSD-2-Clause / Boost dual.
+  Tracked in design doc §3 (PR 4).
+- **uPlot** — bundled at `docs/assets/uplot-<version>.iife.min.js` for
+  the docs chart page, MIT. Tracked in design doc §3 (PR 5).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,6 +24,14 @@ regression gate via [Bencher.dev](https://bencher.dev).
   -> PushResult` / `pop() -> PopResult[T]` shape consumed by the
   shared harness; multi-thread topologies bypass the generic adapter
   and call queue.getProducer(idx) / queue.getConsumer(idx) directly.
+- `nim/smoke/` - Compile-and-run sanity binaries for FFI adapters
+  (`smoke_boost.nim`, `smoke_crossbeam.nim`). Each is a 32-item push/pop
+  round-trip used by CI to fail fast when a system library or cdylib
+  is unavailable, before paying the cost of a full bench compile.
+- `rust/bench-ffi-crossbeam/` - C-ABI cdylib wrapping
+  `crossbeam_queue::ArrayQueue<u64>` and `crossbeam_queue::SegQueue<u64>`.
+  Built with `cargo build --release`; consumed by the Nim Crossbeam
+  adapters via `importc`.
 - `merge_bmf.py` - Stateless union of per-binary BMF JSON fragments
   into a single `merged.json` for `bencher run`. Exits 1 on
   `(slug, measure)` collisions naming the colliding inputs.
@@ -146,6 +154,68 @@ Current slug set emitted across the five binaries:
   `lockfreequeues_unbounded_mupmuc/mpmc_unbounded/{1,2,4}p{1,2,4}c`.
 - `bench_latency`:
   `lockfreequeues_{sipsic,sipmuc,mupsic,mupmuc}/{spsc,mpmc,mpsc,mpmc}/1p1c`.
+
+## Comparison MVP — third-party adapters
+
+PR 3 (Track 3) adds five external-library adapters so each topology has
+≥ 3 distinct libraries plotted on the same Bencher dashboard. All
+adapters are gated behind `-d:adapter_<library_slug>_available`; absent
+gates produce no symbol references and the production builds are
+unchanged.
+
+| Library | Variant | Topology | Compile gate | Install (Linux CI) |
+|---------|---------|----------|--------------|--------------------|
+| Loony | `LoonyQueue` | `mpmc_unbounded` | `-d:adapter_loony_available` | `nimble install loony` |
+| Boost.LockFree | `boost::lockfree::queue` | `mpmc` (bounded) | `-d:adapter_boost_lockfree_queue_available` | `apt install libboost-dev` (requires `nim cpp`) |
+| Boost.LockFree | `boost::lockfree::spsc_queue` | `spsc` (bounded) | `-d:adapter_boost_lockfree_spsc_available` | same as above |
+| Crossbeam | `crossbeam_queue::ArrayQueue` | `mpmc` (bounded) | `-d:adapter_crossbeam_array_queue_available` | `cargo build --release --manifest-path benchmarks/rust/bench-ffi-crossbeam/Cargo.toml` |
+| Crossbeam | `crossbeam_queue::SegQueue` | `mpmc_unbounded` | `-d:adapter_crossbeam_seg_queue_available` | same as above |
+
+Library upstreams: [Loony](https://github.com/shayanhabibi/loony) (MIT),
+[Boost.LockFree](https://www.boost.org/libs/lockfree/) (BSL-1.0),
+[Crossbeam](https://github.com/crossbeam-rs/crossbeam) (Apache-2.0 OR MIT).
+Per-library obligations are tracked in
+[`THIRD_PARTY_LICENSES.md`](../THIRD_PARTY_LICENSES.md).
+
+### CI integration
+
+- **`bench.yml`** runs Loony + Boost.LockFree on every PR using the
+  soft-skip pattern (design 2.6): each library has install -> smoke ->
+  set-flag stages with `continue-on-error: true`; if install or smoke
+  fails the binary compiles without that adapter and the workflow emits
+  a `::warning title=Adapter skipped::...` annotation. The
+  `workflow_dispatch` event also accepts `force_skip_boost` /
+  `force_skip_loony` boolean inputs to exercise the skip path manually.
+- **`bench-comparison.yml`** runs Crossbeam (the only adapter with a
+  Rust toolchain dependency) on a nightly cron + `workflow_dispatch` +
+  targeted path pushes to `devel`. It produces a separate Bencher
+  Report dedicated to crossbeam slugs.
+
+### Running comparison adapters locally
+
+```bash
+# Loony (Nim only):
+nimble install loony
+nim c -r -d:release -d:danger --threads:on \
+  -d:adapter_loony_available \
+  -d:UnboundedMupmucMessageCount=100000 -d:UnboundedMupmucRuns=3 \
+  benchmarks/nim/bench_unbounded.nim loony
+
+# Boost (C++ headers; macOS: brew install boost; Ubuntu: apt install libboost-dev):
+nim cpp -r -d:release -d:danger --threads:on \
+  -d:adapter_boost_lockfree_queue_available \
+  -d:BenchMpmcMessageCount=100000 -d:BenchMpmcRuns=3 \
+  benchmarks/nim/bench_mpmc.nim boost_lockfree_queue
+
+# Crossbeam (Rust cdylib):
+cargo build --release \
+  --manifest-path benchmarks/rust/bench-ffi-crossbeam/Cargo.toml
+nim c -r -d:release -d:danger --threads:on \
+  -d:adapter_crossbeam_array_queue_available \
+  --passL:"-Wl,-rpath,$(pwd)/benchmarks/rust/bench-ffi-crossbeam/target/release" \
+  -d:BenchMpmcMessageCount=100000 -d:BenchMpmcRuns=3 \
+  benchmarks/nim/bench_mpmc.nim crossbeam_array_queue
+```
 
 ## Running merge_bmf and superset_check tests
 

--- a/benchmarks/nim/adapters/boost_lockfree_queue_adapter.nim
+++ b/benchmarks/nim/adapters/boost_lockfree_queue_adapter.nim
@@ -1,0 +1,106 @@
+## Adapter for ``boost::lockfree::queue<uint64_t>`` (MPMC bounded).
+##
+## Boost.LockFree is a header-only C++ library (https://www.boost.org,
+## Boost Software License 1.0). ``boost::lockfree::queue`` is a multi-producer
+## multi-consumer lock-free FIFO over a fixed-size internal node pool;
+## constructed with ``boost::lockfree::queue<T>(capacity)`` it never grows
+## (we pin to ``fixed_sized<true>`` semantics by passing an explicit capacity
+## at construction).
+##
+## Topology: ``mpmc`` bounded. ``topologiesSupported = {tMpmc}``.
+##
+## Build constraint: this adapter is C++ (template-heavy header-only library)
+## and therefore requires ``nim cpp``. Compiling with ``nim c`` triggers an
+## explicit ``{.error.}`` so we never silently fall back to a partial build.
+##
+## Compile-time gating: only included when
+## ``-d:adapter_boost_lockfree_queue_available`` is passed.
+##
+## Header search path: we add ``-I`` for the conventional install locations
+## so the adapter compiles out of the box on Ubuntu (``apt install
+## libboost-dev`` -> ``/usr/include``) and macOS (``brew install boost`` ->
+## ``/opt/homebrew/opt/boost/include`` on arm64, ``/usr/local/include`` on
+## x86_64). On systems where Boost lives elsewhere, set
+## ``-d:boostIncludeDir=<path>`` at compile time.
+
+when defined(adapter_boost_lockfree_queue_available):
+  when not defined(cpp):
+    {.error: "boost_lockfree_queue_adapter requires `nim cpp` (Boost.LockFree is C++).".}
+
+  import ../bench_common
+  import ../adapter
+
+  # Header search paths. Order: explicit override -> brew arm64 -> brew/macports
+  # x86_64 / FreeBSD ports -> Linux apt default.
+  when defined(boostIncludeDir):
+    {.passC: "-I" & boostIncludeDir.}
+  else:
+    when defined(macosx) or defined(macos):
+      {.passC: "-I/opt/homebrew/opt/boost/include".}
+      {.passC: "-I/usr/local/include".}
+    else:
+      {.passC: "-I/usr/include".}
+      {.passC: "-I/usr/local/include".}
+
+  # ``boost::lockfree::queue<T>`` requires ``T`` to be trivially destructible
+  # and trivially copy-assignable; ``uint64_t`` satisfies both. We always
+  # store ``uint64`` regardless of the harness's ``T`` (the harness uses
+  # ``uint64`` as its payload by convention; see ``bench_common.nim``).
+  type
+    BoostQueueRaw {.importcpp: "boost::lockfree::queue<unsigned long long>",
+                    header: "boost/lockfree/queue.hpp", byref.} = object
+
+  proc constructBoostQueueRaw(capacity: csize_t): BoostQueueRaw
+      {.importcpp: "boost::lockfree::queue<unsigned long long>(@)",
+        header: "boost/lockfree/queue.hpp", constructor.}
+
+  proc bpush(q: var BoostQueueRaw; v: culonglong): bool
+      {.importcpp: "#.bounded_push(@)".}
+
+  proc bpop(q: var BoostQueueRaw; v: var culonglong): bool
+      {.importcpp: "#.pop(@)".}
+
+  const topologiesSupported* = {tMpmc}
+
+  type BoostLockfreeQueueAdapter*[T] = object
+    queue*: ptr BoostQueueRaw
+      ## Heap-allocated so the adapter can be moved/copied as a value type
+      ## without invoking C++ move/copy semantics on the underlying queue
+      ## (``boost::lockfree::queue`` is non-copyable and non-movable).
+    capacity*: int
+
+  proc makeBoostLockfreeQueueAdapter*[T](capacity: int = 1024): BoostLockfreeQueueAdapter[T] =
+    ## ``capacity`` is the fixed node-pool size; pushes that exceed it
+    ## return ``prFull``. Default 1024 mirrors other bounded adapters.
+    result.capacity = capacity
+    result.queue = cast[ptr BoostQueueRaw](alloc0(sizeof(BoostQueueRaw)))
+    # Placement-construct the C++ object in the alloc'd storage. Going via
+    # an importcpp constructor proc keeps Nim from emitting a Nim-level
+    # constructor call.
+    {.emit: ["new (", result.queue, ") boost::lockfree::queue<unsigned long long>(", csize_t(capacity), ");"].}
+
+  proc cleanup*[T](a: var BoostLockfreeQueueAdapter[T]) =
+    if a.queue != nil:
+      {.emit: [a.queue, "->~queue();"].}
+      dealloc(a.queue)
+      a.queue = nil
+
+  proc push*[T](a: var BoostLockfreeQueueAdapter[T], item: T): PushResult =
+    if a.queue == nil:
+      return prFull
+    if bpush(a.queue[], culonglong(uint64(item))):
+      prSuccess
+    else:
+      prFull
+
+  proc pop*[T](a: var BoostLockfreeQueueAdapter[T]): PopResult[T] =
+    if a.queue == nil:
+      return PopResult[T](success: false)
+    var raw: culonglong
+    if bpop(a.queue[], raw):
+      PopResult[T](success: true, value: T(uint64(raw)))
+    else:
+      PopResult[T](success: false)
+
+  proc name*[T](a: BoostLockfreeQueueAdapter[T]): string =
+    "boost_lockfree_queue/queue[uint64]"

--- a/benchmarks/nim/adapters/boost_lockfree_queue_adapter.nim
+++ b/benchmarks/nim/adapters/boost_lockfree_queue_adapter.nim
@@ -29,6 +29,7 @@ when defined(adapter_boost_lockfree_queue_available):
 
   import ../bench_common
   import ../adapter
+  import lockfreequeues/internal/aligned_alloc
 
   # Header search paths. Order: explicit override -> brew arm64 -> brew/macports
   # x86_64 / FreeBSD ports -> Linux apt default.
@@ -72,8 +73,13 @@ when defined(adapter_boost_lockfree_queue_available):
   proc makeBoostLockfreeQueueAdapter*[T](capacity: int = 1024): BoostLockfreeQueueAdapter[T] =
     ## ``capacity`` is the fixed node-pool size; pushes that exceed it
     ## return ``prFull``. Default 1024 mirrors other bounded adapters.
+    ## Backing storage uses ``allocAligned`` (cache-line aligned, zeroed)
+    ## rather than ``alloc0`` so the placement-constructed Boost queue gets
+    ## the alignment its internal padding pragmas expect — ``alloc0`` only
+    ## guarantees ``alignof(max_align_t)`` (typically 16 bytes), which can
+    ## leave Boost's per-cache-line atomics straddling line boundaries.
     result.capacity = capacity
-    result.queue = cast[ptr BoostQueueRaw](alloc0(sizeof(BoostQueueRaw)))
+    result.queue = allocAligned[BoostQueueRaw]()
     # Placement-construct the C++ object in the alloc'd storage. Going via
     # an importcpp constructor proc keeps Nim from emitting a Nim-level
     # constructor call.
@@ -82,7 +88,7 @@ when defined(adapter_boost_lockfree_queue_available):
   proc cleanup*[T](a: var BoostLockfreeQueueAdapter[T]) =
     if a.queue != nil:
       {.emit: [a.queue, "->~queue();"].}
-      dealloc(a.queue)
+      freeAligned(a.queue)
       a.queue = nil
 
   proc push*[T](a: var BoostLockfreeQueueAdapter[T], item: T): PushResult =

--- a/benchmarks/nim/adapters/boost_lockfree_spsc_adapter.nim
+++ b/benchmarks/nim/adapters/boost_lockfree_spsc_adapter.nim
@@ -22,6 +22,7 @@ when defined(adapter_boost_lockfree_spsc_available):
 
   import ../bench_common
   import ../adapter
+  import lockfreequeues/internal/aligned_alloc
 
   when defined(boostIncludeDir):
     {.passC: "-I" & boostIncludeDir.}
@@ -51,13 +52,16 @@ when defined(adapter_boost_lockfree_spsc_available):
 
   proc makeBoostLockfreeSpscAdapter*[T](capacity: int = 1024): BoostLockfreeSpscAdapter[T] =
     result.capacity = capacity
-    result.queue = cast[ptr BoostSpscRaw](alloc0(sizeof(BoostSpscRaw)))
+    # `allocAligned` (cache-line aligned, zeroed) instead of `alloc0` so the
+    # placement-constructed Boost spsc_queue gets the alignment its internal
+    # padding pragmas expect; matches the bounded `lockfree::queue` adapter.
+    result.queue = allocAligned[BoostSpscRaw]()
     {.emit: ["new (", result.queue, ") boost::lockfree::spsc_queue<unsigned long long>(", csize_t(capacity), ");"].}
 
   proc cleanup*[T](a: var BoostLockfreeSpscAdapter[T]) =
     if a.queue != nil:
       {.emit: [a.queue, "->~spsc_queue();"].}
-      dealloc(a.queue)
+      freeAligned(a.queue)
       a.queue = nil
 
   proc push*[T](a: var BoostLockfreeSpscAdapter[T], item: T): PushResult =

--- a/benchmarks/nim/adapters/boost_lockfree_spsc_adapter.nim
+++ b/benchmarks/nim/adapters/boost_lockfree_spsc_adapter.nim
@@ -1,0 +1,82 @@
+## Adapter for ``boost::lockfree::spsc_queue<uint64_t>`` (SPSC bounded).
+##
+## ``boost::lockfree::spsc_queue`` is a single-producer single-consumer
+## wait-free ring buffer. It provides stronger progress guarantees than
+## ``boost::lockfree::queue`` (the MPMC version) at the cost of being
+## restricted to one writer + one reader thread.
+##
+## Topology: ``spsc`` bounded. ``topologiesSupported = {tSpsc}``.
+##
+## Build constraint: requires ``nim cpp`` (Boost.LockFree is C++).
+##
+## Compile-time gating: only included when
+## ``-d:adapter_boost_lockfree_spsc_available`` is passed.
+##
+## See ``boost_lockfree_queue_adapter.nim`` for the rationale on header
+## search paths and the heap-allocated indirection (Boost queues are
+## non-copyable, non-movable C++ types).
+
+when defined(adapter_boost_lockfree_spsc_available):
+  when not defined(cpp):
+    {.error: "boost_lockfree_spsc_adapter requires `nim cpp` (Boost.LockFree is C++).".}
+
+  import ../bench_common
+  import ../adapter
+
+  when defined(boostIncludeDir):
+    {.passC: "-I" & boostIncludeDir.}
+  else:
+    when defined(macosx) or defined(macos):
+      {.passC: "-I/opt/homebrew/opt/boost/include".}
+      {.passC: "-I/usr/local/include".}
+    else:
+      {.passC: "-I/usr/include".}
+      {.passC: "-I/usr/local/include".}
+
+  type
+    BoostSpscRaw {.importcpp: "boost::lockfree::spsc_queue<unsigned long long>",
+                   header: "boost/lockfree/spsc_queue.hpp", byref.} = object
+
+  proc bsPush(q: var BoostSpscRaw; v: culonglong): bool
+      {.importcpp: "#.push(@)".}
+
+  proc bsPop(q: var BoostSpscRaw; v: var culonglong): csize_t
+      {.importcpp: "#.pop(&#, 1ULL)".}
+
+  const topologiesSupported* = {tSpsc}
+
+  type BoostLockfreeSpscAdapter*[T] = object
+    queue*: ptr BoostSpscRaw
+    capacity*: int
+
+  proc makeBoostLockfreeSpscAdapter*[T](capacity: int = 1024): BoostLockfreeSpscAdapter[T] =
+    result.capacity = capacity
+    result.queue = cast[ptr BoostSpscRaw](alloc0(sizeof(BoostSpscRaw)))
+    {.emit: ["new (", result.queue, ") boost::lockfree::spsc_queue<unsigned long long>(", csize_t(capacity), ");"].}
+
+  proc cleanup*[T](a: var BoostLockfreeSpscAdapter[T]) =
+    if a.queue != nil:
+      {.emit: [a.queue, "->~spsc_queue();"].}
+      dealloc(a.queue)
+      a.queue = nil
+
+  proc push*[T](a: var BoostLockfreeSpscAdapter[T], item: T): PushResult =
+    if a.queue == nil:
+      return prFull
+    if bsPush(a.queue[], culonglong(uint64(item))):
+      prSuccess
+    else:
+      prFull
+
+  proc pop*[T](a: var BoostLockfreeSpscAdapter[T]): PopResult[T] =
+    if a.queue == nil:
+      return PopResult[T](success: false)
+    var raw: culonglong
+    let n = bsPop(a.queue[], raw)
+    if n == csize_t(1):
+      PopResult[T](success: true, value: T(uint64(raw)))
+    else:
+      PopResult[T](success: false)
+
+  proc name*[T](a: BoostLockfreeSpscAdapter[T]): string =
+    "boost_lockfree_queue/spsc_queue[uint64]"

--- a/benchmarks/nim/adapters/crossbeam_array_queue_adapter.nim
+++ b/benchmarks/nim/adapters/crossbeam_array_queue_adapter.nim
@@ -23,18 +23,11 @@
 when defined(adapter_crossbeam_array_queue_available):
   import ../bench_common
   import ../adapter
-
-  # Skip the link flags if the seg-queue adapter (the other consumer of
-  # the same cdylib) is also enabled; we'd otherwise emit -L/-l twice and
-  # the Apple linker prints a duplicate-library warning. The seg adapter
-  # owns the link-flag emission when both gates are set, since it sorts
-  # last alphabetically among the two crossbeam adapter compile units.
-  when not defined(adapter_crossbeam_seg_queue_available):
-    when defined(crossbeamLibDir):
-      {.passL: "-L" & crossbeamLibDir.}
-    else:
-      {.passL: "-Lbenchmarks/rust/bench-ffi-crossbeam/target/release".}
-    {.passL: "-lbench_ffi_crossbeam".}
+  # Link-flag emission lives in a shared module so it fires exactly once
+  # per bench binary that imports ANY crossbeam adapter, decoupled from
+  # which gates happen to be globally set. See crossbeam_link.nim header
+  # for the failure mode this avoids.
+  import ./crossbeam_link
 
   # The Rust cdylib exports `cb_array_*` with C linkage. We model the
   # opaque queue handle as `pointer` (Nim) <-> `*mut c_void` (Rust). All

--- a/benchmarks/nim/adapters/crossbeam_array_queue_adapter.nim
+++ b/benchmarks/nim/adapters/crossbeam_array_queue_adapter.nim
@@ -1,0 +1,85 @@
+## Adapter for ``crossbeam_queue::ArrayQueue<u64>`` (bounded MPMC).
+##
+## Crossbeam is a Rust lock-free ecosystem (https://github.com/crossbeam-rs,
+## dual-licensed Apache-2.0 / MIT). ``ArrayQueue<T>`` is a fixed-capacity
+## ring-buffer MPMC queue.
+##
+## We do not link directly against the Rust library; instead we go through
+## a thin C-ABI cdylib at ``benchmarks/rust/bench-ffi-crossbeam/`` (see
+## ``Track 3 Task 3.8``). The cdylib exports four ``extern "C"`` fns:
+## ``cb_array_init``, ``cb_array_push``, ``cb_array_pop``, ``cb_array_destroy``.
+##
+## Topology: ``mpmc`` bounded. ``topologiesSupported = {tMpmc}``.
+##
+## Compile-time gating: only included when
+## ``-d:adapter_crossbeam_array_queue_available`` is passed.
+##
+## Linking: callers must build the cdylib first
+## (``cargo build --release --manifest-path benchmarks/rust/bench-ffi-crossbeam/Cargo.toml``)
+## and then compile the bench binary with the link flags emitted below.
+## Override the search path with ``-d:crossbeamLibDir=<path>`` if the crate
+## was built somewhere other than the in-tree ``target/release``.
+
+when defined(adapter_crossbeam_array_queue_available):
+  import ../bench_common
+  import ../adapter
+
+  # Skip the link flags if the seg-queue adapter (the other consumer of
+  # the same cdylib) is also enabled; we'd otherwise emit -L/-l twice and
+  # the Apple linker prints a duplicate-library warning. The seg adapter
+  # owns the link-flag emission when both gates are set, since it sorts
+  # last alphabetically among the two crossbeam adapter compile units.
+  when not defined(adapter_crossbeam_seg_queue_available):
+    when defined(crossbeamLibDir):
+      {.passL: "-L" & crossbeamLibDir.}
+    else:
+      {.passL: "-Lbenchmarks/rust/bench-ffi-crossbeam/target/release".}
+    {.passL: "-lbench_ffi_crossbeam".}
+
+  # The Rust cdylib exports `cb_array_*` with C linkage. We model the
+  # opaque queue handle as `pointer` (Nim) <-> `*mut c_void` (Rust). All
+  # multi-threaded access is the caller's responsibility; the queue
+  # itself is MPMC-safe.
+
+  proc cb_array_init(capacity: csize_t): pointer {.importc, cdecl.}
+  proc cb_array_push(q: pointer; item: uint64): bool {.importc, cdecl.}
+  proc cb_array_pop(q: pointer; outVal: ptr uint64): bool {.importc, cdecl.}
+  proc cb_array_destroy(q: pointer) {.importc, cdecl.}
+
+  const topologiesSupported* = {tMpmc}
+
+  type CrossbeamArrayQueueAdapter*[T] = object
+    queue*: pointer
+    capacity*: int
+
+  proc makeCrossbeamArrayQueueAdapter*[T](capacity: int = 1024): CrossbeamArrayQueueAdapter[T] =
+    doAssert capacity > 0,
+      "CrossbeamArrayQueue requires capacity > 0 (zero would null-init)"
+    result.capacity = capacity
+    result.queue = cb_array_init(csize_t(capacity))
+    doAssert result.queue != nil, "cb_array_init returned null"
+
+  proc cleanup*[T](a: var CrossbeamArrayQueueAdapter[T]) =
+    if a.queue != nil:
+      cb_array_destroy(a.queue)
+      a.queue = nil
+
+  proc push*[T](a: var CrossbeamArrayQueueAdapter[T], item: T): PushResult =
+    if a.queue == nil:
+      return prFull
+    if cb_array_push(a.queue, uint64(item)):
+      prSuccess
+    else:
+      prFull
+
+  proc pop*[T](a: var CrossbeamArrayQueueAdapter[T]): PopResult[T] =
+    if a.queue == nil:
+      return PopResult[T](success: false)
+    var raw: uint64
+    if cb_array_pop(a.queue, addr raw):
+      PopResult[T](success: true, value: T(raw))
+    else:
+      PopResult[T](success: false)
+
+  proc name*[T](a: CrossbeamArrayQueueAdapter[T]): string =
+    "crossbeam_queue/ArrayQueue[u64]"

--- a/benchmarks/nim/adapters/crossbeam_link.nim
+++ b/benchmarks/nim/adapters/crossbeam_link.nim
@@ -1,0 +1,28 @@
+## Shared link-flag emission for the Crossbeam cdylib.
+##
+## Both ``crossbeam_array_queue_adapter`` and ``crossbeam_seg_queue_adapter``
+## link against the same Rust cdylib (``benchmarks/rust/bench-ffi-crossbeam``
+## → ``libbench_ffi_crossbeam``). Each adapter is enabled by its own
+## ``-d:adapter_crossbeam_{array_queue,seg_queue}_available`` gate.
+##
+## Putting ``{.passL.}`` in a shared module guarantees the flags are emitted
+## exactly once per compilation unit that needs them, regardless of which
+## gates are set. Nim module processing dedups: importing this module from
+## both adapters is fine — the pragmas execute once.
+##
+## A common CI configuration sets BOTH adapter gates globally but only
+## imports one adapter into a given bench binary (e.g. ``bench_mpmc`` uses
+## the array variant only; ``bench_unbounded`` uses the seg variant only).
+## The previous design — gating link emission on the OTHER adapter's gate —
+## broke this case: with both gates set, the array adapter would skip
+## emission expecting the seg adapter to handle it, but if seg wasn't
+## imported its emission block was never compiled, leading to undefined
+## symbols at link time. Owning emission here removes that coupling.
+##
+## Override the default search path with ``-d:crossbeamLibDir=<path>``.
+
+when defined(crossbeamLibDir):
+  {.passL: "-L" & crossbeamLibDir.}
+else:
+  {.passL: "-Lbenchmarks/rust/bench-ffi-crossbeam/target/release".}
+{.passL: "-lbench_ffi_crossbeam".}

--- a/benchmarks/nim/adapters/crossbeam_seg_queue_adapter.nim
+++ b/benchmarks/nim/adapters/crossbeam_seg_queue_adapter.nim
@@ -1,0 +1,69 @@
+## Adapter for ``crossbeam_queue::SegQueue<u64>`` (unbounded MPMC).
+##
+## ``SegQueue<T>`` is Crossbeam's unbounded MPMC queue (a Michael-Scott
+## variant); it allocates new segments on demand instead of returning
+## "full". Pushes therefore never report ``prFull`` -- failure can only
+## come from a null queue handle.
+##
+## Topology: ``mpmc_unbounded``. ``topologiesSupported = {tMpmcUnbounded}``.
+##
+## Compile-time gating: only included when
+## ``-d:adapter_crossbeam_seg_queue_available`` is passed.
+##
+## Same cdylib as ``crossbeam_array_queue_adapter``; both adapters can
+## be enabled simultaneously without duplicate symbols (each adapter
+## ``importc`` s a disjoint set of fns: ``cb_array_*`` vs ``cb_seg_*``).
+
+when defined(adapter_crossbeam_seg_queue_available):
+  import ../bench_common
+  import ../adapter
+
+  when defined(crossbeamLibDir):
+    {.passL: "-L" & crossbeamLibDir.}
+  else:
+    {.passL: "-Lbenchmarks/rust/bench-ffi-crossbeam/target/release".}
+
+  {.passL: "-lbench_ffi_crossbeam".}
+
+  proc cb_seg_init(): pointer {.importc, cdecl.}
+  proc cb_seg_push(q: pointer; item: uint64): bool {.importc, cdecl.}
+  proc cb_seg_pop(q: pointer; outVal: ptr uint64): bool {.importc, cdecl.}
+  proc cb_seg_destroy(q: pointer) {.importc, cdecl.}
+
+  const topologiesSupported* = {tMpmcUnbounded}
+
+  type CrossbeamSegQueueAdapter*[T] = object
+    queue*: pointer
+
+  proc makeCrossbeamSegQueueAdapter*[T](capacity: int = 0): CrossbeamSegQueueAdapter[T] =
+    ## ``capacity`` is ignored — SegQueue is unbounded. Default arg matches
+    ## the other adapters' shape so the wire-up sites can pass the same
+    ## ``capacity`` uniformly without conditionals.
+    discard capacity
+    result.queue = cb_seg_init()
+    doAssert result.queue != nil, "cb_seg_init returned null"
+
+  proc cleanup*[T](a: var CrossbeamSegQueueAdapter[T]) =
+    if a.queue != nil:
+      cb_seg_destroy(a.queue)
+      a.queue = nil
+
+  proc push*[T](a: var CrossbeamSegQueueAdapter[T], item: T): PushResult =
+    ## Always succeeds when the queue is alive (SegQueue is unbounded;
+    ## the underlying ``cb_seg_push`` only returns false on a null handle).
+    if a.queue == nil:
+      return prFull
+    discard cb_seg_push(a.queue, uint64(item))
+    prSuccess
+
+  proc pop*[T](a: var CrossbeamSegQueueAdapter[T]): PopResult[T] =
+    if a.queue == nil:
+      return PopResult[T](success: false)
+    var raw: uint64
+    if cb_seg_pop(a.queue, addr raw):
+      PopResult[T](success: true, value: T(raw))
+    else:
+      PopResult[T](success: false)
+
+  proc name*[T](a: CrossbeamSegQueueAdapter[T]): string =
+    "crossbeam_queue/SegQueue[u64]"

--- a/benchmarks/nim/adapters/crossbeam_seg_queue_adapter.nim
+++ b/benchmarks/nim/adapters/crossbeam_seg_queue_adapter.nim
@@ -17,13 +17,9 @@
 when defined(adapter_crossbeam_seg_queue_available):
   import ../bench_common
   import ../adapter
-
-  when defined(crossbeamLibDir):
-    {.passL: "-L" & crossbeamLibDir.}
-  else:
-    {.passL: "-Lbenchmarks/rust/bench-ffi-crossbeam/target/release".}
-
-  {.passL: "-lbench_ffi_crossbeam".}
+  # See ./crossbeam_link.nim — shared link-flag emission, fires once per
+  # bench binary that imports ANY crossbeam adapter.
+  import ./crossbeam_link
 
   proc cb_seg_init(): pointer {.importc, cdecl.}
   proc cb_seg_push(q: pointer; item: uint64): bool {.importc, cdecl.}

--- a/benchmarks/nim/adapters/loony_adapter.nim
+++ b/benchmarks/nim/adapters/loony_adapter.nim
@@ -1,0 +1,72 @@
+## Adapter for the Loony unbounded MPMC queue.
+##
+## Loony is a third-party Nim package (https://github.com/shayanhabibi/loony,
+## MIT-licensed). It exposes ``LoonyQueue[T]`` (a ref) created via
+## ``newLoonyQueue[T]()``, with ``push(q, item)`` and ``pop(q): T``.
+##
+## **Storage constraint.** Loony stores its items as ``uint`` and uses the
+## low 3 bits as ``RESUME``/``WRITER``/``READER`` slot-state flags
+## (``loony/spec.nim``: ``SLOTMASK = ~0x7``). Loony's empty-slot detection
+## reads ``(prev and SLOTMASK) == 0`` — i.e. it treats a zero "pointer"
+## payload as "this slot is empty". Loony was designed for ref/ptr types
+## whose addresses are 8-byte-aligned and never zero. Pushing the literal
+## value ``0`` (or any value whose low 3 bits are non-zero) breaks Loony.
+##
+## To keep the harness's ``push(uint64(i))`` payload semantics intact for
+## ``i in 0 ..< N``, this adapter encodes ``v`` as ``(v + 1) shl 3`` on
+## push and ``(raw shr 3) - 1`` on pop. The ``+1`` ensures the encoded
+## value is never zero (so it can never be misread as an empty slot); the
+## ``shl 3`` keeps the low flag bits clear. This is documentation-
+## equivalent to the way Loony users push ``ref`` values with naturally-
+## non-null, naturally-aligned addresses; it does NOT change the queue
+## algorithm.
+##
+## ``pop`` returns the default-constructed value of ``T`` when the queue is
+## empty, so this adapter consults ``isEmpty(q)`` before each pop.
+##
+## Topology: ``mpmc_unbounded``. Capacity argument is ignored.
+##
+## Compile-time gating: only included when
+## ``-d:adapter_loony_available`` is passed. The bench binary's
+## ``when declared(makeLoonyAdapter):`` block enables the slug only when
+## the gate is set.
+
+when defined(adapter_loony_available):
+  import loony
+  import ../bench_common
+  import ../adapter
+
+  const topologiesSupported* = {tMpmcUnbounded}
+  const LoonyTagShift* = 3
+    ## Number of low bits Loony reserves for slot-state flags. Items with
+    ## non-zero bits in this region collide with RESUME/WRITER/READER.
+
+  type LoonyAdapter*[T] = object
+    queue*: LoonyQueue[uint64]
+      # We always store ``uint64`` regardless of the harness's ``T`` because
+      # we need to control the low-bit aliasing. ``T`` is constrained to
+      # ``uint64`` by the harness today.
+
+  proc makeLoonyAdapter*[T](capacity: int = 0): LoonyAdapter[T] =
+    ## ``capacity`` is ignored — Loony is unbounded.
+    discard capacity
+    result.queue = newLoonyQueue[uint64]()
+
+  proc cleanup*[T](a: var LoonyAdapter[T]) =
+    ## ``LoonyQueue[uint64]`` is a ``ref``; let GC reclaim it when the
+    ## adapter goes out of scope.
+    discard a
+
+  proc push*[T](a: var LoonyAdapter[T], item: T): PushResult =
+    a.queue.push((uint64(item) + 1'u64) shl LoonyTagShift)
+    prSuccess
+
+  proc pop*[T](a: var LoonyAdapter[T]): PopResult[T] =
+    if a.queue.isEmpty():
+      PopResult[T](success: false)
+    else:
+      let raw = a.queue.pop()
+      PopResult[T](success: true, value: T((raw shr LoonyTagShift) - 1'u64))
+
+  proc name*[T](a: LoonyAdapter[T]): string =
+    "loony/LoonyQueue[" & $T & "]"

--- a/benchmarks/nim/adapters/loony_adapter.nim
+++ b/benchmarks/nim/adapters/loony_adapter.nim
@@ -21,8 +21,20 @@
 ## non-null, naturally-aligned addresses; it does NOT change the queue
 ## algorithm.
 ##
-## ``pop`` returns the default-constructed value of ``T`` when the queue is
-## empty, so this adapter consults ``isEmpty(q)`` before each pop.
+## ``pop`` returns the default-constructed value of the queue's element type
+## (``0`` for ``uint64``) when the queue is empty. Because our encoding
+## guarantees that every pushed value is non-zero (``(v + 1) shl 3``), we
+## can use ``raw == 0`` as the empty sentinel directly — racing
+## ``isEmpty()`` against ``pop()`` would leave a window where another
+## consumer drains between the two calls and the second one pops a
+## false-empty.
+##
+## **Encoding range.** ``push`` accepts ``T`` values in
+## ``0 .. uint64.high - 1`` (after the ``+1`` step the upper bound saturates
+## the ``uint64`` width before the ``shl 3``). ``uint64.high`` would wrap
+## to ``0`` and be misread as an empty slot. The harness pushes
+## ``uint64(i)`` for ``i in 0 ..< messageCount`` so this bound is academic
+## at current message-count tuning, but it is the contractual range.
 ##
 ## Topology: ``mpmc_unbounded``. Capacity argument is ignored.
 ##
@@ -62,10 +74,16 @@ when defined(adapter_loony_available):
     prSuccess
 
   proc pop*[T](a: var LoonyAdapter[T]): PopResult[T] =
-    if a.queue.isEmpty():
+    let raw = a.queue.pop()
+    if raw == 0'u64:
+      # Loony returned the default uint64 (0). Our encoding ensures every
+      # pushed value has the form (v+1) shl 3 — strictly non-zero — so
+      # ``raw == 0`` unambiguously means "queue was empty when pop ran".
+      # Doing the empty check on the pop result instead of via a
+      # separate isEmpty() call avoids the empty/pop TOCTOU window
+      # under multi-consumer load.
       PopResult[T](success: false)
     else:
-      let raw = a.queue.pop()
       PopResult[T](success: true, value: T((raw shr LoonyTagShift) - 1'u64))
 
   proc name*[T](a: LoonyAdapter[T]): string =

--- a/benchmarks/nim/adapters/loony_adapter.nim
+++ b/benchmarks/nim/adapters/loony_adapter.nim
@@ -36,10 +36,16 @@
 ## ``0 .. (1'u64 shl 61) - 2`` (≈ ``2.3 * 10^18``). Any value above this
 ## range silently truncates on push and pops back as a different value.
 ## The harness pushes ``uint64(i)`` for ``i in 0 ..< messageCount`` and
-## ``messageCount`` is bounded by ``int.high`` ≈ ``2^63``, far below the
-## safe limit at any tuning we'll ever ship, so this is academic — but
-## it is the contractual range and a debug-mode assert below makes a
-## misuse fail loudly instead of silently corrupting data.
+## ``messageCount`` is a Nim ``int`` whose maximum (``int.high`` ≈
+## ``2^63 - 1``) sits ABOVE the ``2^61 - 2`` encoding ceiling, so the
+## type system alone does NOT guarantee safety. In practice every
+## tuning we ship runs with ``messageCount`` in the millions
+## (``BenchUnboundedMessageCount`` defaults around ``5M``, CI overrides
+## to ``500K``), which is roughly ten orders of magnitude below the
+## ``2^61`` ceiling — academic at every shape we plan to run, but a
+## pathological override could still cross the line. The debug-mode
+## assert below makes a misuse fail loudly instead of silently
+## corrupting data.
 ##
 ## Topology: ``mpmc_unbounded``. Capacity argument is ignored.
 ##

--- a/benchmarks/nim/adapters/loony_adapter.nim
+++ b/benchmarks/nim/adapters/loony_adapter.nim
@@ -29,12 +29,17 @@
 ## consumer drains between the two calls and the second one pops a
 ## false-empty.
 ##
-## **Encoding range.** ``push`` accepts ``T`` values in
-## ``0 .. uint64.high - 1`` (after the ``+1`` step the upper bound saturates
-## the ``uint64`` width before the ``shl 3``). ``uint64.high`` would wrap
-## to ``0`` and be misread as an empty slot. The harness pushes
-## ``uint64(i)`` for ``i in 0 ..< messageCount`` so this bound is academic
-## at current message-count tuning, but it is the contractual range.
+## **Encoding range.** The encoding is ``(v + 1) shl 3`` and pop reverses
+## it as ``(raw shr 3) - 1``. The ``shl 3`` discards the top 3 bits, so
+## the round-trip is invertible only when ``v + 1`` already fits in the
+## low 61 bits — i.e. for input values in the closed range
+## ``0 .. (1'u64 shl 61) - 2`` (≈ ``2.3 * 10^18``). Any value above this
+## range silently truncates on push and pops back as a different value.
+## The harness pushes ``uint64(i)`` for ``i in 0 ..< messageCount`` and
+## ``messageCount`` is bounded by ``int.high`` ≈ ``2^63``, far below the
+## safe limit at any tuning we'll ever ship, so this is academic — but
+## it is the contractual range and a debug-mode assert below makes a
+## misuse fail loudly instead of silently corrupting data.
 ##
 ## Topology: ``mpmc_unbounded``. Capacity argument is ignored.
 ##
@@ -52,6 +57,11 @@ when defined(adapter_loony_available):
   const LoonyTagShift* = 3
     ## Number of low bits Loony reserves for slot-state flags. Items with
     ## non-zero bits in this region collide with RESUME/WRITER/READER.
+  const LoonyMaxValue* = (1'u64 shl (64 - LoonyTagShift)) - 2'u64
+    ## Inclusive upper bound on the input value to ``push``. Above this,
+    ## the ``(v + 1) shl 3`` encoding overflows past 64 bits and the
+    ## round-trip is no longer invertible. See the "Encoding range"
+    ## section in the module docstring.
 
   type LoonyAdapter*[T] = object
     queue*: LoonyQueue[uint64]
@@ -70,6 +80,13 @@ when defined(adapter_loony_available):
     discard a
 
   proc push*[T](a: var LoonyAdapter[T], item: T): PushResult =
+    # Debug-mode assert that the value fits the encoding range. Stripped
+    # in `-d:release`/`-d:danger` builds (which is what the bench
+    # binaries use), so there is zero overhead in measurement runs while
+    # development builds still catch encoding misuse loudly.
+    assert uint64(item) <= LoonyMaxValue,
+      "value " & $uint64(item) & " exceeds Loony adapter encoding range " &
+      "(0 .. " & $LoonyMaxValue & "); see module docstring."
     a.queue.push((uint64(item) + 1'u64) shl LoonyTagShift)
     prSuccess
 

--- a/benchmarks/nim/bench_mpmc.nim
+++ b/benchmarks/nim/bench_mpmc.nim
@@ -31,6 +31,13 @@ import lockfreequeues/mupmuc
 import lockfreequeues/sipmuc
 import lockfreequeues/backoff
 
+# MVP comparison adapters (Track 3). Gated by per-library defines.
+when defined(adapter_boost_lockfree_queue_available):
+  import ./adapters/boost_lockfree_queue_adapter
+
+when defined(adapter_crossbeam_array_queue_available):
+  import ./adapters/crossbeam_array_queue_adapter
+
 const
   BenchMpmcRuns* {.intdefine.} = 33
   BenchMpmcMessageCount* {.intdefine.} = 1_000_000
@@ -268,9 +275,59 @@ proc runChannelsShape(
     metrics.ops_ms_mean + metrics.ops_ms_stddev,
   )
 
+# ---------- MVP adapter dispatch (boost MPMC + crossbeam ArrayQueue) ----------
+#
+# Both MVP adapters expose push/pop directly so they go through
+# runThroughputHarness; the {1,2,4} P x {1,2,4} C grid keeps shape parity
+# with the lockfreequeues mupmuc baseline (≥ 9 shapes per design 2.4).
+
+when defined(adapter_boost_lockfree_queue_available):
+  proc initBoostMpmcQ(capacity: int): BoostLockfreeQueueAdapter[uint64] =
+    makeBoostLockfreeQueueAdapter[uint64](capacity)
+
+when defined(adapter_crossbeam_array_queue_available):
+  proc initCrossbeamArrayQ(capacity: int): CrossbeamArrayQueueAdapter[uint64] =
+    makeCrossbeamArrayQueueAdapter[uint64](capacity)
+
+proc runMvpMpmcShape[A](
+    em: var BMFEmitter,
+    slugPrefix: string,
+    queueInit: proc(capacity: int): A,
+    p, c: int,
+    runs, warmup, messageCount, capacity: int,
+) =
+  let slug = slugPrefix & "/mpmc/" & $p & "p" & $c & "c"
+  echo fmt"{slug}:"
+  let metrics = runThroughputHarness[A](
+    queueInit = queueInit,
+    capacity = capacity,
+    numProducers = p,
+    numConsumers = c,
+    messageCount = messageCount,
+    runCount = runs,
+    warmupCount = warmup,
+  )
+  echo fmt"  mean: {metrics.ops_ms_mean:.1f} ops/ms"
+  echo fmt"  stddev: {metrics.ops_ms_stddev:.1f}"
+  echo fmt"  runs: {metrics.runs}"
+  echo ""
+  em.addMeasure(
+    slug, "throughput_ops_ms",
+    metrics.ops_ms_mean,
+    metrics.ops_ms_mean - metrics.ops_ms_stddev,
+    metrics.ops_ms_mean + metrics.ops_ms_stddev,
+  )
+
 # ---------- Variant dispatch ----------
 
-const SupportedVariants = ["mupmuc", "sipmuc", "channels"]
+proc supportedVariantsList(): seq[string] {.compileTime.} =
+  result = @["mupmuc", "sipmuc", "channels"]
+  when declared(initBoostMpmcQ):
+    result.add("boost_lockfree_queue")
+  when declared(initCrossbeamArrayQ):
+    result.add("crossbeam_array_queue")
+
+const SupportedVariants = supportedVariantsList()
 
 proc runVariant(variant: string, em: var BMFEmitter) =
   case variant
@@ -312,6 +369,24 @@ proc runVariant(variant: string, em: var BMFEmitter) =
         runChannelsShape(em, p, c, BenchMpmcRuns, BenchMpmcWarmup,
                          BenchMpmcMessageCount)
   else:
+    when declared(initBoostMpmcQ):
+      if variant == "boost_lockfree_queue":
+        for p in [1, 2, 4]:
+          for c in [1, 2, 4]:
+            runMvpMpmcShape[BoostLockfreeQueueAdapter[uint64]](
+              em, "boost_lockfree_queue", initBoostMpmcQ,
+              p, c, BenchMpmcRuns, BenchMpmcWarmup,
+              BenchMpmcMessageCount, MpmcCapacity)
+        return
+    when declared(initCrossbeamArrayQ):
+      if variant == "crossbeam_array_queue":
+        for p in [1, 2, 4]:
+          for c in [1, 2, 4]:
+            runMvpMpmcShape[CrossbeamArrayQueueAdapter[uint64]](
+              em, "crossbeam_queue", initCrossbeamArrayQ,
+              p, c, BenchMpmcRuns, BenchMpmcWarmup,
+              BenchMpmcMessageCount, MpmcCapacity)
+        return
     raise newException(ValueError, "unknown variant: " & variant)
 
 when isMainModule:

--- a/benchmarks/nim/bench_mpmc.nim
+++ b/benchmarks/nim/bench_mpmc.nim
@@ -383,7 +383,7 @@ proc runVariant(variant: string, em: var BMFEmitter) =
         for p in [1, 2, 4]:
           for c in [1, 2, 4]:
             runMvpMpmcShape[CrossbeamArrayQueueAdapter[uint64]](
-              em, "crossbeam_queue", initCrossbeamArrayQ,
+              em, "crossbeam_array_queue", initCrossbeamArrayQ,
               p, c, BenchMpmcRuns, BenchMpmcWarmup,
               BenchMpmcMessageCount, MpmcCapacity)
         return

--- a/benchmarks/nim/bench_spsc.nim
+++ b/benchmarks/nim/bench_spsc.nim
@@ -18,6 +18,13 @@ import std/[options, os, parseopt, sets, strformat, syncio]
 import ./bench_common
 import ./adapters/lockfreequeues_sipsic_adapter
 
+# MVP comparison adapters (Track 3). Each is included only when its
+# `-d:adapter_<lib>_available` gate is set; absent gate yields no
+# symbol references and the variant is dropped from `SupportedVariants`
+# below via `when declared(...)`.
+when defined(adapter_boost_lockfree_spsc_available):
+  import ./adapters/boost_lockfree_spsc_adapter
+
 const
   ## Per-binary intdefines for SPSC wall-time control. Override at compile
   ## time with `-d:BenchSpscRuns=N` etc. Defaults match design §2.5.
@@ -46,18 +53,32 @@ proc initSipsicQ(capacity: int): SipsicAdapter[SpscCapacity, uint64] =
   doAssert capacity == SpscCapacity, "capacity must equal SpscCapacity"
   initSipsicAdapter[SpscCapacity, uint64]()
 
-const SupportedVariants = ["sipsic"]
+when defined(adapter_boost_lockfree_spsc_available):
+  proc initBoostSpscQ(capacity: int): BoostLockfreeSpscAdapter[uint64] =
+    makeBoostLockfreeSpscAdapter[uint64](capacity)
 
-proc runVariant(variant: string, em: var BMFEmitter) =
-  let slug =
-    case variant
-    of "sipsic": "lockfreequeues_sipsic/spsc/1p1c"
-    else:
-      raise newException(ValueError, "unknown variant: " & variant)
-  echo fmt"{variant} ({slug}):"
-  let metrics = runThroughputHarness[SipsicAdapter[SpscCapacity, uint64]](
-    queueInit = initSipsicQ,
-    capacity = SpscCapacity,
+# MVP variants are added to SupportedVariants only when the matching
+# adapter symbol is in scope (i.e. its compile-time gate is set).
+proc supportedVariantsList(): seq[string] {.compileTime.} =
+  result = @["sipsic"]
+  when declared(initBoostSpscQ):
+    result.add("boost_lockfree_spsc")
+
+const SupportedVariants = supportedVariantsList()
+
+proc runMvpVariant[A](
+    em: var BMFEmitter,
+    slug: string,
+    queueInit: proc(capacity: int): A,
+    capacity: int,
+) =
+  ## Generic emitter for MVP comparison adapters: 1p1c throughput at
+  ## the same shape as the in-tree sipsic baseline so Bencher can compare
+  ## across libraries on identical work.
+  echo fmt"{slug}:"
+  let metrics = runThroughputHarness[A](
+    queueInit = queueInit,
+    capacity = capacity,
     numProducers = 1,
     numConsumers = 1,
     messageCount = BenchSpscMessageCount,
@@ -74,6 +95,42 @@ proc runVariant(variant: string, em: var BMFEmitter) =
     metrics.ops_ms_mean - metrics.ops_ms_stddev,
     metrics.ops_ms_mean + metrics.ops_ms_stddev,
   )
+
+proc runVariant(variant: string, em: var BMFEmitter) =
+  case variant
+  of "sipsic":
+    let slug = "lockfreequeues_sipsic/spsc/1p1c"
+    echo fmt"{variant} ({slug}):"
+    let metrics = runThroughputHarness[SipsicAdapter[SpscCapacity, uint64]](
+      queueInit = initSipsicQ,
+      capacity = SpscCapacity,
+      numProducers = 1,
+      numConsumers = 1,
+      messageCount = BenchSpscMessageCount,
+      runCount = BenchSpscRuns,
+      warmupCount = BenchSpscWarmup,
+    )
+    echo fmt"  mean: {metrics.ops_ms_mean:.1f} ops/ms"
+    echo fmt"  stddev: {metrics.ops_ms_stddev:.1f}"
+    echo fmt"  runs: {metrics.runs}"
+    echo ""
+    em.addMeasure(
+      slug, "throughput_ops_ms",
+      metrics.ops_ms_mean,
+      metrics.ops_ms_mean - metrics.ops_ms_stddev,
+      metrics.ops_ms_mean + metrics.ops_ms_stddev,
+    )
+  else:
+    when declared(initBoostSpscQ):
+      if variant == "boost_lockfree_spsc":
+        runMvpVariant[BoostLockfreeSpscAdapter[uint64]](
+          em,
+          slug = "boost_lockfree_queue/spsc/1p1c",
+          queueInit = initBoostSpscQ,
+          capacity = SpscCapacity,
+        )
+        return
+    raise newException(ValueError, "unknown variant: " & variant)
 
 when isMainModule:
   # Unbuffer stdout so progress is visible under file redirects (mirrors

--- a/benchmarks/nim/bench_unbounded.nim
+++ b/benchmarks/nim/bench_unbounded.nim
@@ -44,6 +44,14 @@ import lockfreequeues/unbounded_mupmuc
 import lockfreequeues/unbounded_mupsic
 import debra
 
+# MVP comparison adapters (Track 3). Loony is unbounded MPMC; Crossbeam
+# SegQueue is unbounded MPMC. Both go through runThroughputHarness.
+when defined(adapter_loony_available):
+  import ./adapters/loony_adapter
+
+when defined(adapter_crossbeam_seg_queue_available):
+  import ./adapters/crossbeam_seg_queue_adapter
+
 const
   UnboundedSipsicRuns* {.intdefine.} = 3
   UnboundedSipsicMessageCount* {.intdefine.} = 500_000
@@ -458,11 +466,62 @@ proc runUMupmucShape[P: static int; C: static int](
   echo ""
   em.addMeasure(slug, "throughput_ops_ms", m, m - s, m + s)
 
+# ---------- MVP unbounded MPMC adapter dispatch (loony + crossbeam SegQueue) ----------
+#
+# Both adapters expose plain push/pop and are unbounded, so they fit the
+# stock runThroughputHarness over the {1,2,4} P x {1,2,4} C grid for
+# parity with the lockfreequeues mupmuc unbounded baseline.
+
+when defined(adapter_loony_available):
+  proc initLoonyQ(capacity: int): LoonyAdapter[uint64] =
+    discard capacity
+    makeLoonyAdapter[uint64]()
+
+when defined(adapter_crossbeam_seg_queue_available):
+  proc initCrossbeamSegQ(capacity: int): CrossbeamSegQueueAdapter[uint64] =
+    discard capacity
+    makeCrossbeamSegQueueAdapter[uint64]()
+
+proc runMvpUnboundedShape[A](
+    em: var BMFEmitter,
+    slugPrefix: string,
+    queueInit: proc(capacity: int): A,
+    p, c: int,
+    runs, warmup, messageCount: int,
+) =
+  let slug = slugPrefix & "/mpmc_unbounded/" & $p & "p" & $c & "c"
+  echo fmt"{slug}:"
+  let metrics = runThroughputHarness[A](
+    queueInit = queueInit,
+    capacity = 0,
+    numProducers = p,
+    numConsumers = c,
+    messageCount = messageCount,
+    runCount = runs,
+    warmupCount = warmup,
+  )
+  echo fmt"  mean: {metrics.ops_ms_mean:.1f} ops/ms"
+  echo fmt"  stddev: {metrics.ops_ms_stddev:.1f}"
+  echo fmt"  runs: {metrics.runs}"
+  echo ""
+  em.addMeasure(
+    slug, "throughput_ops_ms",
+    metrics.ops_ms_mean,
+    metrics.ops_ms_mean - metrics.ops_ms_stddev,
+    metrics.ops_ms_mean + metrics.ops_ms_stddev,
+  )
+
 # ---------- Variant dispatch ----------
 
-const SupportedVariants =
-  ["unbounded_sipsic", "unbounded_sipmuc",
-   "unbounded_mupsic", "unbounded_mupmuc"]
+proc supportedVariantsList(): seq[string] {.compileTime.} =
+  result = @["unbounded_sipsic", "unbounded_sipmuc",
+             "unbounded_mupsic", "unbounded_mupmuc"]
+  when declared(initLoonyQ):
+    result.add("loony")
+  when declared(initCrossbeamSegQ):
+    result.add("crossbeam_seg_queue")
+
+const SupportedVariants = supportedVariantsList()
 
 proc runVariant(variant: string, em: var BMFEmitter) =
   case variant
@@ -518,6 +577,24 @@ proc runVariant(variant: string, em: var BMFEmitter) =
       runUMupmucShape[4, 4](em, UnboundedMupmucRuns, BenchUnboundedWarmup,
         UnboundedMupmucMessageCount)
   else:
+    when declared(initLoonyQ):
+      if variant == "loony":
+        for p in [1, 2, 4]:
+          for c in [1, 2, 4]:
+            runMvpUnboundedShape[LoonyAdapter[uint64]](
+              em, "loony/LoonyQueue", initLoonyQ,
+              p, c, UnboundedMupmucRuns, BenchUnboundedWarmup,
+              UnboundedMupmucMessageCount)
+        return
+    when declared(initCrossbeamSegQ):
+      if variant == "crossbeam_seg_queue":
+        for p in [1, 2, 4]:
+          for c in [1, 2, 4]:
+            runMvpUnboundedShape[CrossbeamSegQueueAdapter[uint64]](
+              em, "crossbeam_queue/SegQueue", initCrossbeamSegQ,
+              p, c, UnboundedMupmucRuns, BenchUnboundedWarmup,
+              UnboundedMupmucMessageCount)
+        return
     raise newException(ValueError, "unknown variant: " & variant)
 
 when isMainModule:

--- a/benchmarks/nim/bench_unbounded.nim
+++ b/benchmarks/nim/bench_unbounded.nim
@@ -582,7 +582,7 @@ proc runVariant(variant: string, em: var BMFEmitter) =
         for p in [1, 2, 4]:
           for c in [1, 2, 4]:
             runMvpUnboundedShape[LoonyAdapter[uint64]](
-              em, "loony/LoonyQueue", initLoonyQ,
+              em, "loony", initLoonyQ,
               p, c, UnboundedMupmucRuns, BenchUnboundedWarmup,
               UnboundedMupmucMessageCount)
         return
@@ -591,7 +591,7 @@ proc runVariant(variant: string, em: var BMFEmitter) =
         for p in [1, 2, 4]:
           for c in [1, 2, 4]:
             runMvpUnboundedShape[CrossbeamSegQueueAdapter[uint64]](
-              em, "crossbeam_queue/SegQueue", initCrossbeamSegQ,
+              em, "crossbeam_seg_queue", initCrossbeamSegQ,
               p, c, UnboundedMupmucRuns, BenchUnboundedWarmup,
               UnboundedMupmucMessageCount)
         return

--- a/benchmarks/nim/smoke/smoke_boost.nim
+++ b/benchmarks/nim/smoke/smoke_boost.nim
@@ -1,0 +1,68 @@
+## Compile-and-run smoke for the Boost.LockFree adapters.
+##
+## Used by ``bench.yml`` (Track 3 §3.12) as a sanity check that the apt-
+## installed ``libboost-dev`` headers are present and resolvable, before
+## the full bench binaries run with the same defines.
+##
+## Build:
+##   nim cpp -d:adapter_boost_lockfree_queue_available \
+##           -d:adapter_boost_lockfree_spsc_available \
+##           benchmarks/nim/smoke/smoke_boost.nim
+##
+## Either define alone is sufficient; both are accepted so a single
+## smoke binary covers both adapters.
+
+import std/syncio
+
+when defined(adapter_boost_lockfree_queue_available):
+  import ../adapters/boost_lockfree_queue_adapter
+  import ../adapter
+
+when defined(adapter_boost_lockfree_spsc_available):
+  import ../adapters/boost_lockfree_spsc_adapter
+  import ../adapter
+
+when not defined(adapter_boost_lockfree_queue_available) and
+     not defined(adapter_boost_lockfree_spsc_available):
+  {.error: "smoke_boost requires at least one of -d:adapter_boost_lockfree_queue_available or -d:adapter_boost_lockfree_spsc_available.".}
+
+proc main() =
+  setStdIoUnbuffered()
+  echo "boost smoke: starting"
+
+  when defined(adapter_boost_lockfree_queue_available):
+    block boostQueue:
+      var a = makeBoostLockfreeQueueAdapter[uint64](capacity = 64)
+      defer: cleanup(a)
+      for i in 0'u64 ..< 32'u64:
+        let r = a.push(i)
+        doAssert r == prSuccess, "boost queue push failed at i=" & $i
+      var seen = 0
+      while true:
+        let r = a.pop()
+        if not r.success:
+          break
+        inc seen
+      doAssert seen == 32, "boost queue popped " & $seen & " (expected 32)"
+      echo "boost queue: 32 push/pop ok"
+
+  when defined(adapter_boost_lockfree_spsc_available):
+    block boostSpsc:
+      var a = makeBoostLockfreeSpscAdapter[uint64](capacity = 64)
+      defer: cleanup(a)
+      for i in 0'u64 ..< 32'u64:
+        let r = a.push(i)
+        doAssert r == prSuccess, "boost spsc push failed at i=" & $i
+      var seen = 0
+      while true:
+        let r = a.pop()
+        if not r.success:
+          break
+        inc seen
+      doAssert seen == 32, "boost spsc popped " & $seen & " (expected 32)"
+      echo "boost spsc: 32 push/pop ok"
+
+  echo "boost smoke: ok"
+
+when isMainModule:
+  main()

--- a/benchmarks/nim/smoke/smoke_crossbeam.nim
+++ b/benchmarks/nim/smoke/smoke_crossbeam.nim
@@ -1,0 +1,68 @@
+## Compile-and-run smoke for the Crossbeam adapters.
+##
+## Used by ``bench-comparison.yml`` (Track 3 §3.13) as a sanity check that
+## the cdylib is on the search path before the full bench binaries run.
+##
+## Build:
+##   cargo build --release --manifest-path \
+##     benchmarks/rust/bench-ffi-crossbeam/Cargo.toml
+##   nim c -d:adapter_crossbeam_array_queue_available \
+##         -d:adapter_crossbeam_seg_queue_available \
+##         --passL:-Wl,-rpath,benchmarks/rust/bench-ffi-crossbeam/target/release \
+##         benchmarks/nim/smoke/smoke_crossbeam.nim
+##
+## (the ``-rpath`` is only needed for run-time dlopen on Linux; on macOS
+## the dylib's install_name resolves via the ``-L`` path.)
+
+import std/syncio
+
+when defined(adapter_crossbeam_array_queue_available):
+  import ../adapters/crossbeam_array_queue_adapter
+  import ../adapter
+
+when defined(adapter_crossbeam_seg_queue_available):
+  import ../adapters/crossbeam_seg_queue_adapter
+  import ../adapter
+
+when not defined(adapter_crossbeam_array_queue_available) and
+     not defined(adapter_crossbeam_seg_queue_available):
+  {.error: "smoke_crossbeam requires at least one of -d:adapter_crossbeam_array_queue_available or -d:adapter_crossbeam_seg_queue_available.".}
+
+proc main() =
+  setStdIoUnbuffered()
+  echo "crossbeam smoke: starting"
+
+  when defined(adapter_crossbeam_array_queue_available):
+    block array:
+      var a = makeCrossbeamArrayQueueAdapter[uint64](capacity = 64)
+      defer: cleanup(a)
+      for i in 0'u64 ..< 32'u64:
+        let r = a.push(i)
+        doAssert r == prSuccess, "crossbeam array push failed at i=" & $i
+      var seen = 0
+      while true:
+        let r = a.pop()
+        if not r.success: break
+        inc seen
+      doAssert seen == 32, "crossbeam array popped " & $seen & " (expected 32)"
+      echo "crossbeam ArrayQueue: 32 push/pop ok"
+
+  when defined(adapter_crossbeam_seg_queue_available):
+    block seg:
+      var a = makeCrossbeamSegQueueAdapter[uint64]()
+      defer: cleanup(a)
+      for i in 0'u64 ..< 32'u64:
+        let r = a.push(i)
+        doAssert r == prSuccess, "crossbeam seg push failed at i=" & $i
+      var seen = 0
+      while true:
+        let r = a.pop()
+        if not r.success: break
+        inc seen
+      doAssert seen == 32, "crossbeam seg popped " & $seen & " (expected 32)"
+      echo "crossbeam SegQueue: 32 push/pop ok"
+
+  echo "crossbeam smoke: ok"
+
+when isMainModule:
+  main()

--- a/benchmarks/rust/bench-ffi-crossbeam/Cargo.toml
+++ b/benchmarks/rust/bench-ffi-crossbeam/Cargo.toml
@@ -13,3 +13,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 crossbeam-queue = "0.3"
+
+[profile.release]
+# Unwinding a Rust panic across the C-ABI boundary into Nim is undefined
+# behavior (the Nim caller has no panic-aware unwinder). `panic = "abort"`
+# turns any in-FFI panic into an immediate process abort, which is the
+# only sound option for a `cdylib` exposed to a non-Rust runtime.
+panic = "abort"

--- a/benchmarks/rust/bench-ffi-crossbeam/Cargo.toml
+++ b/benchmarks/rust/bench-ffi-crossbeam/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bench_ffi_crossbeam"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "C-ABI cdylib wrapping crossbeam-queue::ArrayQueue and SegQueue for the lockfreequeues bench harness"
+license = "Apache-2.0 OR MIT"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+# rlib is included so `cargo test` can link the integration test binary
+# against the same code path that the cdylib exposes.
+
+[dependencies]
+crossbeam-queue = "0.3"

--- a/benchmarks/rust/bench-ffi-crossbeam/rust-toolchain.toml
+++ b/benchmarks/rust/bench-ffi-crossbeam/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+profile = "minimal"
+components = ["rustc", "cargo"]

--- a/benchmarks/rust/bench-ffi-crossbeam/src/lib.rs
+++ b/benchmarks/rust/bench-ffi-crossbeam/src/lib.rs
@@ -1,0 +1,155 @@
+//! C-ABI shim around `crossbeam_queue::ArrayQueue` and `crossbeam_queue::SegQueue`.
+//!
+//! Exposes 8 `extern "C"` functions for the Nim bench adapters:
+//!
+//! | Function           | Backing type                      |
+//! |--------------------|-----------------------------------|
+//! | cb_array_init      | crossbeam_queue::ArrayQueue<u64>  |
+//! | cb_array_push      | "                                 |
+//! | cb_array_pop       | "                                 |
+//! | cb_array_destroy   | "                                 |
+//! | cb_seg_init        | crossbeam_queue::SegQueue<u64>    |
+//! | cb_seg_push        | "                                 |
+//! | cb_seg_pop         | "                                 |
+//! | cb_seg_destroy     | "                                 |
+//!
+//! All eight functions are panic-safe relative to the Rust side: they
+//! perform their own null-pointer checks. They are NOT thread-safe with
+//! respect to `*_destroy` (the queues themselves are MPMC-safe, but
+//! freeing the queue while another thread is mid-push/mid-pop is a UAF).
+//! The Nim-side adapters guarantee `cleanup` is called only after all
+//! producer / consumer threads have joined.
+//!
+//! Object lifetime: each `*_init` allocates the queue on the Rust heap
+//! via `Box::into_raw`. The returned `*mut c_void` must be passed back
+//! to the matching `*_destroy` to reclaim it; intermediate `_push` /
+//! `_pop` calls borrow it immutably (the queue's interior mutability
+//! handles the writes).
+
+use crossbeam_queue::{ArrayQueue, SegQueue};
+use std::os::raw::c_void;
+
+// ---------------- ArrayQueue (bounded MPMC) ----------------
+
+/// Allocate a bounded `ArrayQueue<u64>` of `capacity`. Returns the queue
+/// pointer (opaque to the caller). Caller must pair with `cb_array_destroy`.
+///
+/// `capacity` must be > 0; passing 0 returns null (an `ArrayQueue::new(0)`
+/// would panic inside crossbeam, which would unwind across the FFI boundary).
+#[unsafe(no_mangle)]
+pub extern "C" fn cb_array_init(capacity: usize) -> *mut c_void {
+    if capacity == 0 {
+        return std::ptr::null_mut();
+    }
+    let q = Box::new(ArrayQueue::<u64>::new(capacity));
+    Box::into_raw(q) as *mut c_void
+}
+
+/// Push `item` onto the array queue. Returns true on success, false if
+/// the queue is full or `q` is null.
+///
+/// # Safety
+/// `q` must be a pointer previously returned by `cb_array_init` and not
+/// yet passed to `cb_array_destroy`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cb_array_push(q: *mut c_void, item: u64) -> bool {
+    if q.is_null() {
+        return false;
+    }
+    let q = unsafe { &*(q as *const ArrayQueue<u64>) };
+    q.push(item).is_ok()
+}
+
+/// Pop one item; on success writes it to `*out` and returns true. Returns
+/// false if the queue is empty, `q` is null, or `out` is null.
+///
+/// # Safety
+/// `q` must be a live ArrayQueue pointer (see `cb_array_push`); `out`
+/// must point to writable storage of at least `sizeof(u64)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cb_array_pop(q: *mut c_void, out: *mut u64) -> bool {
+    if q.is_null() || out.is_null() {
+        return false;
+    }
+    let q = unsafe { &*(q as *const ArrayQueue<u64>) };
+    match q.pop() {
+        Some(v) => {
+            unsafe { std::ptr::write(out, v); }
+            true
+        }
+        None => false,
+    }
+}
+
+/// Free the array queue. Tolerates a null pointer (no-op).
+///
+/// # Safety
+/// `q` must be a pointer previously returned by `cb_array_init` and not
+/// yet destroyed. After the call, `q` is dangling.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cb_array_destroy(q: *mut c_void) {
+    if q.is_null() {
+        return;
+    }
+    drop(unsafe { Box::from_raw(q as *mut ArrayQueue<u64>) });
+}
+
+// ---------------- SegQueue (unbounded MPMC) ----------------
+
+/// Allocate an unbounded `SegQueue<u64>`. Caller must pair with
+/// `cb_seg_destroy`.
+#[unsafe(no_mangle)]
+pub extern "C" fn cb_seg_init() -> *mut c_void {
+    let q = Box::new(SegQueue::<u64>::new());
+    Box::into_raw(q) as *mut c_void
+}
+
+/// Push `item` onto the seg queue. SegQueue is unbounded, so this never
+/// reports "full"; failure is only possible on a null pointer (returns
+/// false). On success returns true.
+///
+/// # Safety
+/// `q` must be a live SegQueue pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cb_seg_push(q: *mut c_void, item: u64) -> bool {
+    if q.is_null() {
+        return false;
+    }
+    let q = unsafe { &*(q as *const SegQueue<u64>) };
+    q.push(item);
+    true
+}
+
+/// Pop one item; on success writes it to `*out` and returns true.
+/// Returns false on empty / null pointers (same convention as the array
+/// variant).
+///
+/// # Safety
+/// See `cb_array_pop`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cb_seg_pop(q: *mut c_void, out: *mut u64) -> bool {
+    if q.is_null() || out.is_null() {
+        return false;
+    }
+    let q = unsafe { &*(q as *const SegQueue<u64>) };
+    match q.pop() {
+        Some(v) => {
+            unsafe { std::ptr::write(out, v); }
+            true
+        }
+        None => false,
+    }
+}
+
+/// Free the seg queue. Tolerates a null pointer (no-op).
+///
+/// # Safety
+/// `q` must be a pointer previously returned by `cb_seg_init` and not
+/// yet destroyed. After the call, `q` is dangling.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cb_seg_destroy(q: *mut c_void) {
+    if q.is_null() {
+        return;
+    }
+    drop(unsafe { Box::from_raw(q as *mut SegQueue<u64>) });
+}

--- a/benchmarks/rust/bench-ffi-crossbeam/tests/integration_test.rs
+++ b/benchmarks/rust/bench-ffi-crossbeam/tests/integration_test.rs
@@ -1,0 +1,121 @@
+//! Integration test for the C-ABI surface. Calls the public extern "C"
+//! functions directly through the rlib so the same code path the cdylib
+//! exports is exercised end-to-end (init -> N pushes -> N pops -> destroy)
+//! with count + set assertions matching the Nim adapter's smoke test.
+
+use std::collections::HashSet;
+use std::os::raw::c_void;
+
+use bench_ffi_crossbeam::{
+    cb_array_destroy, cb_array_init, cb_array_pop, cb_array_push,
+    cb_seg_destroy, cb_seg_init, cb_seg_pop, cb_seg_push,
+};
+
+// Bind the local names the tests use so the rest of the file (which
+// passes raw `*mut c_void`) reads identically to the cdylib consumer.
+// Each call site below uses the imported function directly.
+#[allow(dead_code)]
+fn _shape_check() -> *mut c_void {
+    std::ptr::null_mut()
+}
+
+const N: u64 = 1000;
+
+#[test]
+fn array_queue_round_trip_preserves_set() {
+    unsafe {
+        let q = cb_array_init(N as usize);
+        assert!(!q.is_null());
+
+        let mut pushed: HashSet<u64> = HashSet::new();
+        for i in 0..N {
+            assert!(cb_array_push(q, i), "array push failed at i={i}");
+            pushed.insert(i);
+        }
+
+        let mut popped: HashSet<u64> = HashSet::new();
+        let mut out: u64 = 0;
+        while cb_array_pop(q, &mut out) {
+            popped.insert(out);
+        }
+
+        assert_eq!(popped.len() as u64, N);
+        assert_eq!(pushed, popped);
+
+        cb_array_destroy(q);
+    }
+}
+
+#[test]
+fn array_queue_full_returns_false() {
+    unsafe {
+        let q = cb_array_init(2);
+        assert!(cb_array_push(q, 10));
+        assert!(cb_array_push(q, 20));
+        assert!(!cb_array_push(q, 30), "expected push to fail at capacity");
+        cb_array_destroy(q);
+    }
+}
+
+#[test]
+fn array_queue_zero_capacity_returns_null() {
+    // `cb_array_init` is not `unsafe` (it has no preconditions on a
+    // 0-arg path), so the test body intentionally does not wrap it.
+    // Guard against the upstream panic on ArrayQueue::new(0); we
+    // return null instead so the FFI never unwinds.
+    let q = cb_array_init(0);
+    assert!(q.is_null());
+}
+
+#[test]
+fn seg_queue_round_trip_preserves_set() {
+    unsafe {
+        let q = cb_seg_init();
+        assert!(!q.is_null());
+
+        let mut pushed: HashSet<u64> = HashSet::new();
+        for i in 0..N {
+            assert!(cb_seg_push(q, i));
+            pushed.insert(i);
+        }
+
+        let mut popped: HashSet<u64> = HashSet::new();
+        let mut out: u64 = 0;
+        while cb_seg_pop(q, &mut out) {
+            popped.insert(out);
+        }
+
+        assert_eq!(popped.len() as u64, N);
+        assert_eq!(pushed, popped);
+
+        cb_seg_destroy(q);
+    }
+}
+
+#[test]
+fn pop_empty_returns_false() {
+    unsafe {
+        let q = cb_array_init(4);
+        let mut out: u64 = 999;
+        assert!(!cb_array_pop(q, &mut out));
+        assert_eq!(out, 999, "out unchanged on empty pop");
+        cb_array_destroy(q);
+
+        let q = cb_seg_init();
+        assert!(!cb_seg_pop(q, &mut out));
+        cb_seg_destroy(q);
+    }
+}
+
+#[test]
+fn null_pointer_safe() {
+    unsafe {
+        let mut out: u64 = 0;
+        assert!(!cb_array_push(std::ptr::null_mut(), 1));
+        assert!(!cb_array_pop(std::ptr::null_mut(), &mut out));
+        assert!(!cb_seg_push(std::ptr::null_mut(), 1));
+        assert!(!cb_seg_pop(std::ptr::null_mut(), &mut out));
+        cb_array_destroy(std::ptr::null_mut());
+        cb_seg_destroy(std::ptr::null_mut());
+    }
+}

--- a/lockfreequeues.nimble
+++ b/lockfreequeues.nimble
@@ -84,6 +84,7 @@ task benchtests, "Runs the bench harness test suite":
   # land.
   exec "nim c --threads:on -r -f tests/t_bench_common.nim"
   exec "nim c --threads:on -r -f tests/t_bench_latency.nim"
+  exec "nim c --threads:on -r -f tests/t_bench_adapters.nim"
 
 
 task stresstests, "Runs the stress test suite (multi-threaded)":

--- a/src/lockfreequeues/internal/aligned_alloc.nim
+++ b/src/lockfreequeues/internal/aligned_alloc.nim
@@ -7,10 +7,21 @@
 ## offsets that share a 16-byte-aligned base with adjacent allocations.
 ##
 ## ``c_calloc`` / ``c_malloc`` only guarantee ``2 * sizeof(size_t) == 16`` bytes
-## of alignment under glibc and macOS libSystem. Without ``posix_memalign``, the
-## first cache-line slot of every Segment is split across two physical lines
-## and false-shares with whatever neighbours the heap happens to place
-## adjacent.
+## of alignment under glibc and macOS libSystem. Without an aligned-allocation
+## primitive, the first cache-line slot of every Segment is split across two
+## physical lines and false-shares with whatever neighbours the heap happens
+## to place adjacent.
+##
+## Platform mapping:
+##
+## * POSIX (Linux, macOS): ``posix_memalign`` from ``<stdlib.h>``. Memory is
+##   compatible with the standard ``free`` per POSIX.
+## * Windows (MSVC + MinGW runtime): ``_aligned_malloc`` from ``<malloc.h>``.
+##   Memory MUST be freed with ``_aligned_free`` — using ``free`` corrupts
+##   the heap.
+##
+## Both backends are wrapped behind ``allocAligned[T]() / freeAligned(p)`` so
+## callers don't have to ``when defined(windows):`` at every site.
 ##
 ## Compile probe verified at impl-plan time (Task 3.2.0): the C
 ## ``posix_memalign`` from ``<stdlib.h>`` is callable from both ``nim c`` and
@@ -25,9 +36,18 @@
 ## The local importc shim below uses the canonical C signature, which
 ## clang accepts in both C and C++ modes.
 
-proc posix_memalign(
-    memptr: ptr pointer, alignment: csize_t, size: csize_t
-): cint {.importc, header: "<stdlib.h>".}
+when defined(windows):
+  proc aligned_malloc(
+      size: csize_t, alignment: csize_t
+  ): pointer {.importc: "_aligned_malloc", header: "<malloc.h>".}
+  proc aligned_free(
+      memblock: pointer
+  ) {.importc: "_aligned_free", header: "<malloc.h>".}
+else:
+  proc posix_memalign(
+      memptr: ptr pointer, alignment: csize_t, size: csize_t
+  ): cint {.importc, header: "<stdlib.h>".}
+  from system/ansi_c import c_free
 
 import ../atomic_dsl
 export CacheLineBytes
@@ -39,24 +59,48 @@ proc allocAligned*[T](): ptr T =
   ## Raises ``OutOfMemDefect`` on allocation failure (matches the existing
   ## ``c_calloc`` failure path in unbounded queue ``newSegment`` procs).
   ##
-  ## The caller owns the returned pointer; release with ``freeAligned`` or
-  ## the standard ``c_free`` (``posix_memalign`` blocks are compatible with
-  ## ``free`` per POSIX).
+  ## The caller owns the returned pointer; release with ``freeAligned``,
+  ## which routes to the platform-correct deallocator (``free`` on POSIX,
+  ## ``_aligned_free`` on Windows).
   ##
-  ## ``posix_memalign`` requires ``alignment`` to be a power of two and a
-  ## multiple of ``sizeof(pointer)``. ``CacheLineBytes`` (64) satisfies both
-  ## on every platform we target; ``alignof(T)`` is always a power of two
-  ## per the C standard, and an over-aligned ``T`` (e.g. an SSE/AVX vector
-  ## or a manually ``{.align: 128.}``-pragma'd object) would have
+  ## Both backends require ``alignment`` to be a power of two; the Windows
+  ## ``_aligned_malloc`` accepts any power of two, while POSIX
+  ## ``posix_memalign`` additionally requires a multiple of
+  ## ``sizeof(pointer)``. ``CacheLineBytes`` (64) satisfies both on every
+  ## platform we target; ``alignof(T)`` is always a power of two per the
+  ## C standard, and an over-aligned ``T`` (e.g. an SSE/AVX vector or a
+  ## manually ``{.align: 128.}``-pragma'd object) would have
   ## ``alignof(T) >= sizeof(pointer)`` as well, so taking ``max`` of the
   ## two keeps the constraint valid. We compute the max at compile time so
   ## the runtime alignment argument is constant per instantiation.
   const alignment = max(CacheLineBytes, alignof(T))
-  var p: pointer
-  if posix_memalign(addr p, csize_t(alignment), csize_t(sizeof(T))) != 0:
-    raise newException(OutOfMemDefect, "posix_memalign failed for " & $T)
+  when defined(windows):
+    let p = aligned_malloc(csize_t(sizeof(T)), csize_t(alignment))
+    if p == nil:
+      raise newException(OutOfMemDefect, "_aligned_malloc failed for " & $T)
+  else:
+    var p: pointer
+    if posix_memalign(addr p, csize_t(alignment), csize_t(sizeof(T))) != 0:
+      raise newException(OutOfMemDefect, "posix_memalign failed for " & $T)
   zeroMem(p, sizeof(T))
   result = cast[ptr T](p)
+
+proc freeAligned*(p: pointer) {.inline.} =
+  ## Release a pointer obtained from ``allocAligned``. Does nothing on a
+  ## ``nil`` argument so callers can use it idempotently in destructors.
+  ## Takes ``pointer`` (not ``ptr T``) so callers in untyped destructor
+  ## hooks (where the segment type has been erased to ``pointer``) can
+  ## use the same call site as typed callers.
+  if p == nil: return
+  when defined(windows):
+    aligned_free(p)
+  else:
+    c_free(p)
+
+proc freeAligned*[T](p: ptr T) {.inline.} =
+  ## Typed convenience overload that forwards to the ``pointer`` variant.
+  ## Lets callers pass ``ptr T`` without an explicit cast.
+  freeAligned(cast[pointer](p))
 
 when isMainModule:
   # Smoke test: verify allocAligned returns 64-byte aligned memory.
@@ -67,3 +111,4 @@ when isMainModule:
   doAssert p != nil
   doAssert (cast[uint](p) mod CacheLineBytes.uint) == 0
   echo "allocAligned[Probe] -> ", cast[uint](p), " (mod 64 = ", cast[uint](p) mod 64'u, ")"
+  freeAligned(p)

--- a/src/lockfreequeues/internal/aligned_alloc.nim
+++ b/src/lockfreequeues/internal/aligned_alloc.nim
@@ -1,0 +1,48 @@
+## Cache-line-aligned heap allocation for unbounded queue Segments.
+##
+## Project-wide invariant (design doc §4.2): every ``Segment[S, T]`` allocation
+## must be aligned to ``CacheLineBytes`` (64 on x86_64) so that the
+## ``{.align: CacheLineBytes.}`` pragma on internal Atomic fields lifts those
+## fields onto distinct physical cache lines, not merely distinct intra-struct
+## offsets that share a 16-byte-aligned base with adjacent allocations.
+##
+## ``c_calloc`` / ``c_malloc`` only guarantee ``2 * sizeof(size_t) == 16`` bytes
+## of alignment under glibc and macOS libSystem. Without ``posix_memalign``, the
+## first cache-line slot of every Segment is split across two physical lines
+## and false-shares with whatever neighbours the heap happens to place
+## adjacent.
+##
+## Compile probe verified at impl-plan time (Task 3.2.0): ``std/posix`` exports
+## ``posix_memalign`` on both macOS (libSystem) and Linux glibc with the same
+## C signature ``int posix_memalign(void**, size_t, size_t)``. Allocation
+## returns 64-byte aligned memory and ``rc == 0`` on success.
+
+import std/posix
+
+import ../atomic_dsl
+export CacheLineBytes
+
+proc allocAligned*[T](): ptr T =
+  ## Allocate one zero-initialized ``T`` on a ``CacheLineBytes`` boundary.
+  ##
+  ## Raises ``OutOfMemDefect`` on allocation failure (matches the existing
+  ## ``c_calloc`` failure path in unbounded queue ``newSegment`` procs).
+  ##
+  ## The caller owns the returned pointer; release with ``freeAligned`` or
+  ## the standard ``c_free`` (``posix_memalign`` blocks are compatible with
+  ## ``free`` per POSIX).
+  var p: pointer
+  if posix_memalign(addr p, csize_t(CacheLineBytes), csize_t(sizeof(T))) != 0:
+    raise newException(OutOfMemDefect, "posix_memalign failed for " & $T)
+  zeroMem(p, sizeof(T))
+  result = cast[ptr T](p)
+
+when isMainModule:
+  # Smoke test: verify allocAligned returns 64-byte aligned memory.
+  type Probe = object
+    a: int
+    b: array[128, byte]
+  let p = allocAligned[Probe]()
+  doAssert p != nil
+  doAssert (cast[uint](p) mod CacheLineBytes.uint) == 0
+  echo "allocAligned[Probe] -> ", cast[uint](p), " (mod 64 = ", cast[uint](p) mod 64'u, ")"

--- a/src/lockfreequeues/internal/aligned_alloc.nim
+++ b/src/lockfreequeues/internal/aligned_alloc.nim
@@ -12,12 +12,22 @@
 ## and false-shares with whatever neighbours the heap happens to place
 ## adjacent.
 ##
-## Compile probe verified at impl-plan time (Task 3.2.0): ``std/posix`` exports
-## ``posix_memalign`` on both macOS (libSystem) and Linux glibc with the same
-## C signature ``int posix_memalign(void**, size_t, size_t)``. Allocation
-## returns 64-byte aligned memory and ``rc == 0`` on success.
+## Compile probe verified at impl-plan time (Task 3.2.0): the C
+## ``posix_memalign`` from ``<stdlib.h>`` is callable from both ``nim c`` and
+## ``nim cpp`` on macOS (libSystem) and Linux glibc, returning 64-byte
+## aligned memory and ``rc == 0`` on success.
+##
+## Note: ``std/posix.posix_memalign`` was the first candidate, but on macOS
+## the Apple SDK declares the first parameter with the
+## ``__unsafe_indexable`` attribute under C++, which the Nim wrapper does
+## not match — ``nim cpp`` then fails with
+## "cannot convert argument of incomplete type 'void *' to 'void **'".
+## The local importc shim below uses the canonical C signature, which
+## clang accepts in both C and C++ modes.
 
-import std/posix
+proc posix_memalign(
+    memptr: ptr pointer, alignment: csize_t, size: csize_t
+): cint {.importc, header: "<stdlib.h>".}
 
 import ../atomic_dsl
 export CacheLineBytes

--- a/src/lockfreequeues/internal/aligned_alloc.nim
+++ b/src/lockfreequeues/internal/aligned_alloc.nim
@@ -33,7 +33,8 @@ import ../atomic_dsl
 export CacheLineBytes
 
 proc allocAligned*[T](): ptr T =
-  ## Allocate one zero-initialized ``T`` on a ``CacheLineBytes`` boundary.
+  ## Allocate one zero-initialized ``T`` on at least a ``CacheLineBytes``
+  ## boundary, but honor ``alignof(T)`` if it is larger.
   ##
   ## Raises ``OutOfMemDefect`` on allocation failure (matches the existing
   ## ``c_calloc`` failure path in unbounded queue ``newSegment`` procs).
@@ -41,8 +42,18 @@ proc allocAligned*[T](): ptr T =
   ## The caller owns the returned pointer; release with ``freeAligned`` or
   ## the standard ``c_free`` (``posix_memalign`` blocks are compatible with
   ## ``free`` per POSIX).
+  ##
+  ## ``posix_memalign`` requires ``alignment`` to be a power of two and a
+  ## multiple of ``sizeof(pointer)``. ``CacheLineBytes`` (64) satisfies both
+  ## on every platform we target; ``alignof(T)`` is always a power of two
+  ## per the C standard, and an over-aligned ``T`` (e.g. an SSE/AVX vector
+  ## or a manually ``{.align: 128.}``-pragma'd object) would have
+  ## ``alignof(T) >= sizeof(pointer)`` as well, so taking ``max`` of the
+  ## two keeps the constraint valid. We compute the max at compile time so
+  ## the runtime alignment argument is constant per instantiation.
+  const alignment = max(CacheLineBytes, alignof(T))
   var p: pointer
-  if posix_memalign(addr p, csize_t(CacheLineBytes), csize_t(sizeof(T))) != 0:
+  if posix_memalign(addr p, csize_t(alignment), csize_t(sizeof(T))) != 0:
     raise newException(OutOfMemDefect, "posix_memalign failed for " & $T)
   zeroMem(p, sizeof(T))
   result = cast[ptr T](p)

--- a/src/lockfreequeues/unbounded_mupmuc.nim
+++ b/src/lockfreequeues/unbounded_mupmuc.nim
@@ -37,7 +37,6 @@ import ./backoff
 import ./internal/aligned_alloc
 import std/options
 import std/typetraits
-from system/ansi_c import c_free
 
 import debra
 
@@ -167,19 +166,24 @@ proc newUnboundedMupmuc*[S: static int, T; MaxThreads: static int](
   ## `=destroy` after segment cleanup. For multi-queue setups that
   ## share a manager, use the `(manager, strategy)` overload instead.
   let mgr = allocAligned[DebraManager[MaxThreads]]()
+  var ok = false
   try:
     mgr[] = initDebraManager[MaxThreads]()
     result = newUnboundedMupmuc[S, T, MaxThreads](mgr, strategy)
     result.ownsManager = true
-  except:
-    # Run the manager's =destroy (drains any limbo bags + asserts the
-    # client refcount is zero) before freeing the heap slot. Safe for
-    # both partially- and fully-initialized state because c_calloc
-    # zeroed it: nil limboBagTail pointers walk no list, boundClients
-    # is 0 so the destructor's invariant assertion passes.
-    reset(mgr[])
-    c_free(mgr)
-    raise
+    ok = true
+  finally:
+    # `finally` (not `except:`) so the cleanup also runs on `Defect`-class
+    # raises (e.g. `OutOfMemDefect` from inside `initDebraManager`). Under
+    # Nim 2.0, bare `except:` matches only `CatchableError`, leaving
+    # Defect-shaped failures to leak `mgr`. Run the manager's `=destroy`
+    # (drains any limbo bags + asserts the client refcount is zero) before
+    # freeing the heap slot. Safe for both partially- and fully-initialized
+    # state because `allocAligned` zeroed it: nil limboBagTail pointers walk
+    # no list, boundClients is 0 so the destructor's invariant passes.
+    if not ok:
+      reset(mgr[])
+      freeAligned(mgr)
 
 proc segmentCount*[S: static int, T; MaxThreads: static int](
     self: var UnboundedMupmuc[S, T, MaxThreads]
@@ -286,7 +290,7 @@ proc push*[S: static int, T; MaxThreads: static int](
           else:
             # Lost the segment-alloc race: another producer linked first.
             # Free our orphan segment and back off before retrying.
-            c_free(newSeg)
+            freeAligned(newSeg)
             backoffOnRetry(spins)
             continue
         else:
@@ -317,14 +321,14 @@ proc push*[S: static int, T; MaxThreads: static int](
 # Typed destructor for retired segments. Must be generic over `(S, T)`
 # because the segment's `data: array[S, T]` slots may hold managed types
 # (`string`, `seq`, `ref`, ...) whose internal allocations would leak if
-# we just `c_free`'d the segment block. For POD `T` (`supportsCopyMem`),
+# we just `freeAligned`'d the segment block. For POD `T` (`supportsCopyMem`),
 # the `reset` loop is compile-time-elided, so this costs nothing.
 proc segmentDestructor[S: static int, T](p: pointer) {.nimcall, raises: [].} =
   when not supportsCopyMem(T):
     let seg = cast[ptr Segment[S, T]](p)
     for i in 0 ..< S:
       reset(seg.data[i])
-  c_free(p)
+  freeAligned(p)
 
 proc pop*[S: static int, T; MaxThreads: static int](
     self: var Consumer[S, T, MaxThreads]
@@ -462,11 +466,11 @@ proc `=destroy`*[S: static int, T; MaxThreads: static int](
     let next = seg.next.load(moRelaxed)
     when not supportsCopyMem(T):
       # Run the destructor for any managed slots (string/seq/ref) before
-      # `c_free`'s away the segment block — otherwise their internal
+      # `freeAligned`'s away the segment block — otherwise their internal
       # allocations leak.
       for i in 0 ..< S:
         reset(seg.data[i])
-    c_free(seg)
+    freeAligned(seg)
     seg = next
 
   # Release our refcount on the manager. Conceptually pairs with the
@@ -480,4 +484,4 @@ proc `=destroy`*[S: static int, T; MaxThreads: static int](
       # without the parsing surprise of the backtick form, which trips
       # `expr(nkIdent); unknown node kind` inside a generic destructor.
       reset(self.manager[])
-      c_free(self.manager)
+      freeAligned(self.manager)

--- a/src/lockfreequeues/unbounded_mupmuc.nim
+++ b/src/lockfreequeues/unbounded_mupmuc.nim
@@ -433,6 +433,25 @@ proc pop*[S: static int, T; MaxThreads: static int](
     return none(seq[T])
   return some(items)
 
+when defined(testing):
+  proc headSegmentForTest*[S: static int, T; MaxThreads: static int](
+      self: var UnboundedMupmuc[S, T, MaxThreads]
+  ): pointer =
+    ## Test-only accessor: returns the queue's current head segment pointer
+    ## so the cache-line padding audit can verify base alignment.
+    result = cast[pointer](self.headSegment.load(moRelaxed))
+
+  proc segmentHeadOffsetForTest*[S: static int, T; MaxThreads: static int](
+      _: typedesc[UnboundedMupmuc[S, T, MaxThreads]]
+  ): tuple[tail: int, prevConsumerIdx: int, committed: int] =
+    ## Test-only accessor: returns offsets of cache-line-padded fields within
+    ## the unbounded mupmuc Segment for the cache-line padding audit.
+    result = (
+      offsetOf(Segment[S, T], tail),
+      offsetOf(Segment[S, T], prevConsumerIdx),
+      offsetOf(Segment[S, T], committed),
+    )
+
 proc `=destroy`*[S: static int, T; MaxThreads: static int](
     self: var UnboundedMupmuc[S, T, MaxThreads]
 ) =

--- a/src/lockfreequeues/unbounded_mupmuc.nim
+++ b/src/lockfreequeues/unbounded_mupmuc.nim
@@ -166,13 +166,7 @@ proc newUnboundedMupmuc*[S: static int, T; MaxThreads: static int](
   ## owned by this queue. Manager teardown happens inside this queue's
   ## `=destroy` after segment cleanup. For multi-queue setups that
   ## share a manager, use the `(manager, strategy)` overload instead.
-  let mgr = cast[ptr DebraManager[MaxThreads]](
-    c_calloc(1.csize_t, sizeof(DebraManager[MaxThreads]).csize_t)
-  )
-  if mgr == nil:
-    raise newException(
-      OutOfMemDefect, "newUnboundedMupmuc: c_calloc returned nil"
-    )
+  let mgr = allocAligned[DebraManager[MaxThreads]]()
   try:
     mgr[] = initDebraManager[MaxThreads]()
     result = newUnboundedMupmuc[S, T, MaxThreads](mgr, strategy)

--- a/src/lockfreequeues/unbounded_mupmuc.nim
+++ b/src/lockfreequeues/unbounded_mupmuc.nim
@@ -34,9 +34,10 @@
 
 import ./atomic_dsl
 import ./backoff
+import ./internal/aligned_alloc
 import std/options
 import std/typetraits
-from system/ansi_c import c_calloc, c_free
+from system/ansi_c import c_free
 
 import debra
 
@@ -64,10 +65,13 @@ else:
 type
   Segment[S: static int, T] = object ## A fixed-size segment in the linked list.
     data: array[S, T]
-    next: Atomic[ptr Segment[S, T]]
-    tail: Atomic[int] # CAS coordination for producers
-    prevConsumerIdx: Atomic[int] # CAS coordination for consumers
-    committed: array[S, Atomic[bool]] # Track which slots are ready to read
+    next {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+    tail {.align: CacheLineBytes.}: Atomic[int]
+      # CAS coordination for producers
+    prevConsumerIdx {.align: CacheLineBytes.}: Atomic[int]
+      # CAS coordination for consumers
+    committed {.align: CacheLineBytes.}: array[S, Atomic[bool]]
+      # Track which slots are ready to read
 
   UnboundedMupmuc*[S: static int, T; MaxThreads: static int] = object
     ## Unbounded MPMC queue using linked segments.
@@ -76,8 +80,10 @@ type
     ## - T: Data type.
     ## - MaxThreads: Maximum number of threads (compile-time constant).
     manager: ptr DebraManager[MaxThreads]
-    headSegment: Atomic[ptr Segment[S, T]] # Consumers read from here
-    tailSegment: Atomic[ptr Segment[S, T]] # Producers write here
+    headSegment {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+      # Consumers read from here
+    tailSegment {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+      # Producers write here
     strategy: DeallocationStrategy
     itemCount: Atomic[int] # Total items in queue
     segments: Atomic[int] # Number of segments
@@ -105,10 +111,9 @@ type
     handle: ThreadHandle[MaxThreads]
 
 proc newSegment[S: static int, T](): ptr Segment[S, T] =
-  ## Allocate a new segment via libc calloc (zero-initialized, truly shared).
-  result = cast[ptr Segment[S, T]](c_calloc(1.csize_t, sizeof(Segment[S, T]).csize_t))
-  if result == nil:
-    raise newException(OutOfMemDefect, "newSegment: c_calloc returned nil")
+  ## Allocate a new segment on a CacheLineBytes boundary so the
+  ## ``{.align.}`` pragmas above land on distinct physical cache lines.
+  result = allocAligned[Segment[S, T]]()
   result.next.store(nil, moRelaxed)
   result.tail.store(0, moRelaxed)
   result.prevConsumerIdx.store(-1, moRelaxed)

--- a/src/lockfreequeues/unbounded_mupsic.nim
+++ b/src/lockfreequeues/unbounded_mupsic.nim
@@ -39,7 +39,6 @@ import ./backoff
 import ./internal/aligned_alloc
 import std/options
 import std/typetraits
-from system/ansi_c import c_free
 
 import debra
 
@@ -70,7 +69,12 @@ type
     next {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
     tail {.align: CacheLineBytes.}: Atomic[int]
       # CAS coordination for producers
-    head: int # Consumer read position within segment (single consumer, no atomic)
+    head {.align: CacheLineBytes.}: int
+      # Consumer read position within segment (single consumer, no atomic).
+      # Aligned to its own cache line so consumer head writes do not
+      # invalidate producers' cached `tail` line. Without the pragma `head`
+      # would share a 64-byte chunk with `tail` because Nim packs object
+      # fields back-to-back unless explicitly aligned.
     committed {.align: CacheLineBytes.}: array[S, Atomic[bool]]
       # Track which slots are ready to read
 
@@ -171,19 +175,24 @@ proc newUnboundedMupsic*[S: static int, T; MaxThreads: static int](
   ##
   ## For multi-queue setups that share a manager, pass it explicitly.
   let mgr = allocAligned[DebraManager[MaxThreads]]()
+  var ok = false
   try:
     mgr[] = initDebraManager[MaxThreads]()
     let consumerHandle = registerThread(mgr[])
     result = newUnboundedMupsic[S, T, MaxThreads](mgr, consumerHandle, strategy)
     result.ownsManager = true
-  except:
-    # Run the manager's =destroy (drains any limbo bags + asserts the
-    # client refcount is zero) before freeing the heap slot. Safe for
-    # both partially- and fully-initialized state because c_calloc
-    # zeroed it.
-    reset(mgr[])
-    c_free(mgr)
-    raise
+    ok = true
+  finally:
+    # `finally` (not `except:`) so the cleanup also runs on `Defect`-class
+    # raises (e.g. `OutOfMemDefect` from inside `initDebraManager`). Under
+    # Nim 2.0, bare `except:` matches only `CatchableError`, leaving
+    # Defect-shaped failures to leak `mgr`. Run the manager's `=destroy`
+    # (drains any limbo bags + asserts the client refcount is zero) before
+    # freeing the heap slot. Safe for both partially- and fully-initialized
+    # state because `allocAligned` zeroed it.
+    if not ok:
+      reset(mgr[])
+      freeAligned(mgr)
 
 proc segmentCount*[S: static int, T; MaxThreads: static int](
     self: var UnboundedMupsic[S, T, MaxThreads]
@@ -266,7 +275,7 @@ proc push*[S: static int, T; MaxThreads: static int](
             continue
           else:
             # Lost the segment-alloc race, free our orphan and back off.
-            c_free(newSeg)
+            freeAligned(newSeg)
             backoffOnRetry(spins)
             continue
         else:
@@ -298,14 +307,14 @@ proc push*[S: static int, T; MaxThreads: static int](
 
 # Typed destructor for retired segments. Generic over `(S, T)` so we can
 # `reset` any managed slots (`string`, `seq`, `ref`, ...) before
-# `c_free`'s away the segment block. For POD `T` (`supportsCopyMem`),
+# `freeAligned`'s away the segment block. For POD `T` (`supportsCopyMem`),
 # the loop is compile-time-elided.
 proc segmentDestructor[S: static int, T](p: pointer) {.nimcall, raises: [].} =
   when not supportsCopyMem(T):
     let seg = cast[ptr Segment[S, T]](p)
     for i in 0 ..< S:
       reset(seg.data[i])
-  c_free(p)
+  freeAligned(p)
 
 proc pop*[S: static int, T; MaxThreads: static int](
     self: var UnboundedMupsic[S, T, MaxThreads]
@@ -402,10 +411,16 @@ when defined(testing):
 
   proc segmentHeadOffsetForTest*[S: static int, T; MaxThreads: static int](
       _: typedesc[UnboundedMupsic[S, T, MaxThreads]]
-  ): tuple[tail: int, committed: int] =
+  ): tuple[tail: int, head: int, committed: int] =
     ## Test-only accessor: returns offsets of cache-line-padded fields within
-    ## the unbounded mupsic Segment for the cache-line padding audit.
-    result = (offsetOf(Segment[S, T], tail), offsetOf(Segment[S, T], committed))
+    ## the unbounded mupsic Segment for the cache-line padding audit. ``head``
+    ## (consumer cursor) MUST live on its own line because every consumer write
+    ## would otherwise invalidate producers' cached ``tail``.
+    result = (
+      offsetOf(Segment[S, T], tail),
+      offsetOf(Segment[S, T], head),
+      offsetOf(Segment[S, T], committed),
+    )
 
 proc `=destroy`*[S: static int, T; MaxThreads: static int](
     self: var UnboundedMupsic[S, T, MaxThreads]
@@ -418,11 +433,11 @@ proc `=destroy`*[S: static int, T; MaxThreads: static int](
     let next = seg.next.load(moRelaxed)
     when not supportsCopyMem(T):
       # Run the destructor for any managed slots (string/seq/ref) before
-      # `c_free`'s away the segment block — otherwise their internal
+      # `freeAligned`'s away the segment block — otherwise their internal
       # allocations leak.
       for i in 0 ..< S:
         reset(seg.data[i])
-    c_free(seg)
+    freeAligned(seg)
     seg = next
 
   # Release our refcount on the manager. Conceptually pairs with the
@@ -436,4 +451,4 @@ proc `=destroy`*[S: static int, T; MaxThreads: static int](
       # without the parsing surprise of the backtick form, which trips
       # `expr(nkIdent); unknown node kind` inside a generic destructor.
       reset(self.manager[])
-      c_free(self.manager)
+      freeAligned(self.manager)

--- a/src/lockfreequeues/unbounded_mupsic.nim
+++ b/src/lockfreequeues/unbounded_mupsic.nim
@@ -394,6 +394,21 @@ proc pop*[S: static int, T; MaxThreads: static int](
     return none(seq[T])
   return some(items)
 
+when defined(testing):
+  proc headSegmentForTest*[S: static int, T; MaxThreads: static int](
+      self: var UnboundedMupsic[S, T, MaxThreads]
+  ): pointer =
+    ## Test-only accessor: returns the queue's current head segment pointer
+    ## so the cache-line padding audit can verify base alignment.
+    result = cast[pointer](self.headSegment.load(moRelaxed))
+
+  proc segmentHeadOffsetForTest*[S: static int, T; MaxThreads: static int](
+      _: typedesc[UnboundedMupsic[S, T, MaxThreads]]
+  ): tuple[tail: int, committed: int] =
+    ## Test-only accessor: returns offsets of cache-line-padded fields within
+    ## the unbounded mupsic Segment for the cache-line padding audit.
+    result = (offsetOf(Segment[S, T], tail), offsetOf(Segment[S, T], committed))
+
 proc `=destroy`*[S: static int, T; MaxThreads: static int](
     self: var UnboundedMupsic[S, T, MaxThreads]
 ) =

--- a/src/lockfreequeues/unbounded_mupsic.nim
+++ b/src/lockfreequeues/unbounded_mupsic.nim
@@ -170,13 +170,7 @@ proc newUnboundedMupsic*[S: static int, T; MaxThreads: static int](
   ## handle obtained on the consumer thread.
   ##
   ## For multi-queue setups that share a manager, pass it explicitly.
-  let mgr = cast[ptr DebraManager[MaxThreads]](
-    c_calloc(1.csize_t, sizeof(DebraManager[MaxThreads]).csize_t)
-  )
-  if mgr == nil:
-    raise newException(
-      OutOfMemDefect, "newUnboundedMupsic: c_calloc returned nil"
-    )
+  let mgr = allocAligned[DebraManager[MaxThreads]]()
   try:
     mgr[] = initDebraManager[MaxThreads]()
     let consumerHandle = registerThread(mgr[])

--- a/src/lockfreequeues/unbounded_mupsic.nim
+++ b/src/lockfreequeues/unbounded_mupsic.nim
@@ -36,9 +36,10 @@
 
 import ./atomic_dsl
 import ./backoff
+import ./internal/aligned_alloc
 import std/options
 import std/typetraits
-from system/ansi_c import c_calloc, c_free
+from system/ansi_c import c_free
 
 import debra
 
@@ -66,10 +67,12 @@ else:
 type
   Segment[S: static int, T] = object ## A fixed-size segment in the linked list.
     data: array[S, T]
-    next: Atomic[ptr Segment[S, T]]
-    tail: Atomic[int] # CAS coordination for producers
+    next {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+    tail {.align: CacheLineBytes.}: Atomic[int]
+      # CAS coordination for producers
     head: int # Consumer read position within segment (single consumer, no atomic)
-    committed: array[S, Atomic[bool]] # Track which slots are ready to read
+    committed {.align: CacheLineBytes.}: array[S, Atomic[bool]]
+      # Track which slots are ready to read
 
   UnboundedMupsic*[S: static int, T; MaxThreads: static int] = object
     ## Unbounded MPSC queue using linked segments.
@@ -78,8 +81,10 @@ type
     ## - T: Data type.
     ## - MaxThreads: Maximum number of threads (compile-time constant).
     manager: ptr DebraManager[MaxThreads]
-    headSegment: Atomic[ptr Segment[S, T]] # Consumer reads from here
-    tailSegment: Atomic[ptr Segment[S, T]] # Producers write here (atomic for CAS)
+    headSegment {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+      # Consumer reads from here
+    tailSegment {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+      # Producers write here (atomic for CAS)
     strategy: DeallocationStrategy
     handle: ThreadHandle[MaxThreads] # Consumer's handle (single consumer)
     itemCount: Atomic[int] # Total items in queue
@@ -100,10 +105,9 @@ type
     handle: ThreadHandle[MaxThreads] # Each producer has its own handle
 
 proc newSegment[S: static int, T](): ptr Segment[S, T] =
-  ## Allocate a new segment via libc calloc (zero-initialized, truly shared).
-  result = cast[ptr Segment[S, T]](c_calloc(1.csize_t, sizeof(Segment[S, T]).csize_t))
-  if result == nil:
-    raise newException(OutOfMemDefect, "newSegment: c_calloc returned nil")
+  ## Allocate a new segment on a CacheLineBytes boundary so the
+  ## ``{.align.}`` pragmas above land on distinct physical cache lines.
+  result = allocAligned[Segment[S, T]]()
   result.next.store(nil, moRelaxed)
   result.tail.store(0, moRelaxed)
   result.head = 0

--- a/src/lockfreequeues/unbounded_sipmuc.nim
+++ b/src/lockfreequeues/unbounded_sipmuc.nim
@@ -38,9 +38,10 @@
 
 import ./atomic_dsl
 import ./backoff
+import ./internal/aligned_alloc
 import std/options
 import std/typetraits
-from system/ansi_c import c_calloc, c_free
+from system/ansi_c import c_free
 
 import debra
 
@@ -68,9 +69,11 @@ else:
 type
   Segment[S: static int, T] = object ## A fixed-size segment in the linked list.
     data: array[S, T]
-    next: Atomic[ptr Segment[S, T]]
-    tail: Atomic[int] # Producer write position within segment
-    prevConsumerIdx: Atomic[int] # CAS coordination for consumers
+    next {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+    tail {.align: CacheLineBytes.}: Atomic[int]
+      # Producer write position within segment
+    prevConsumerIdx {.align: CacheLineBytes.}: Atomic[int]
+      # CAS coordination for consumers
 
   UnboundedSipmuc*[S: static int, T; MaxThreads: static int] = object
     ## Unbounded SPMC queue using linked segments.
@@ -79,8 +82,10 @@ type
     ## - T: Data type.
     ## - MaxThreads: Maximum number of threads (compile-time constant).
     manager: ptr DebraManager[MaxThreads]
-    headSegment: Atomic[ptr Segment[S, T]] # Consumers read from here
-    tailSegment: ptr Segment[S, T] # Producer writes here (single-producer)
+    headSegment {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+      # Consumers read from here
+    tailSegment {.align: CacheLineBytes.}: ptr Segment[S, T]
+      # Producer writes here (single-producer)
     strategy: DeallocationStrategy
     itemCount: Atomic[int] # Total items in queue
     segments: Atomic[int] # Number of segments
@@ -103,10 +108,9 @@ type
     handle: ThreadHandle[MaxThreads] # Thread handle for pin/unpin
 
 proc newSegment[S: static int, T](): ptr Segment[S, T] =
-  ## Allocate a new segment via libc calloc (zero-initialized, truly shared).
-  result = cast[ptr Segment[S, T]](c_calloc(1.csize_t, sizeof(Segment[S, T]).csize_t))
-  if result == nil:
-    raise newException(OutOfMemDefect, "newSegment: c_calloc returned nil")
+  ## Allocate a new segment on a CacheLineBytes boundary so the
+  ## ``{.align.}`` pragmas above land on distinct physical cache lines.
+  result = allocAligned[Segment[S, T]]()
   result.next.store(nil, moRelaxed)
   result.tail.store(0, moRelaxed)
   result.prevConsumerIdx.store(-1, moRelaxed) # No consumer yet

--- a/src/lockfreequeues/unbounded_sipmuc.nim
+++ b/src/lockfreequeues/unbounded_sipmuc.nim
@@ -164,13 +164,7 @@ proc newUnboundedSipmuc*[S: static int, T; MaxThreads: static int](
   ## owned by this queue. Manager teardown happens inside this queue's
   ## `=destroy` after segment cleanup. For multi-queue setups that
   ## share a manager, use the `(manager, strategy)` overload instead.
-  let mgr = cast[ptr DebraManager[MaxThreads]](
-    c_calloc(1.csize_t, sizeof(DebraManager[MaxThreads]).csize_t)
-  )
-  if mgr == nil:
-    raise newException(
-      OutOfMemDefect, "newUnboundedSipmuc: c_calloc returned nil"
-    )
+  let mgr = allocAligned[DebraManager[MaxThreads]]()
   try:
     mgr[] = initDebraManager[MaxThreads]()
     result = newUnboundedSipmuc[S, T, MaxThreads](mgr, strategy)

--- a/src/lockfreequeues/unbounded_sipmuc.nim
+++ b/src/lockfreequeues/unbounded_sipmuc.nim
@@ -373,6 +373,21 @@ proc pop*[S: static int, T; MaxThreads: static int](
     return none(seq[T])
   return some(items)
 
+when defined(testing):
+  proc headSegmentForTest*[S: static int, T; MaxThreads: static int](
+      self: var UnboundedSipmuc[S, T, MaxThreads]
+  ): pointer =
+    ## Test-only accessor: returns the queue's current head segment pointer
+    ## so the cache-line padding audit can verify base alignment.
+    result = cast[pointer](self.headSegment.load(moRelaxed))
+
+  proc segmentHeadOffsetForTest*[S: static int, T; MaxThreads: static int](
+      _: typedesc[UnboundedSipmuc[S, T, MaxThreads]]
+  ): tuple[tail: int, prevConsumerIdx: int] =
+    ## Test-only accessor: returns offsets of cache-line-padded fields within
+    ## the unbounded sipmuc Segment for the cache-line padding audit.
+    result = (offsetOf(Segment[S, T], tail), offsetOf(Segment[S, T], prevConsumerIdx))
+
 proc `=destroy`*[S: static int, T; MaxThreads: static int](
     self: var UnboundedSipmuc[S, T, MaxThreads]
 ) =

--- a/src/lockfreequeues/unbounded_sipmuc.nim
+++ b/src/lockfreequeues/unbounded_sipmuc.nim
@@ -41,7 +41,6 @@ import ./backoff
 import ./internal/aligned_alloc
 import std/options
 import std/typetraits
-from system/ansi_c import c_free
 
 import debra
 
@@ -165,18 +164,23 @@ proc newUnboundedSipmuc*[S: static int, T; MaxThreads: static int](
   ## `=destroy` after segment cleanup. For multi-queue setups that
   ## share a manager, use the `(manager, strategy)` overload instead.
   let mgr = allocAligned[DebraManager[MaxThreads]]()
+  var ok = false
   try:
     mgr[] = initDebraManager[MaxThreads]()
     result = newUnboundedSipmuc[S, T, MaxThreads](mgr, strategy)
     result.ownsManager = true
-  except:
-    # Run the manager's =destroy (drains any limbo bags + asserts the
-    # client refcount is zero) before freeing the heap slot. Safe for
-    # both partially- and fully-initialized state because c_calloc
-    # zeroed it.
-    reset(mgr[])
-    c_free(mgr)
-    raise
+    ok = true
+  finally:
+    # `finally` (not `except:`) so the cleanup also runs on `Defect`-class
+    # raises (e.g. `OutOfMemDefect` from inside `initDebraManager`). Under
+    # Nim 2.0, bare `except:` matches only `CatchableError`, leaving
+    # Defect-shaped failures to leak `mgr`. Run the manager's `=destroy`
+    # (drains any limbo bags + asserts the client refcount is zero) before
+    # freeing the heap slot. Safe for both partially- and fully-initialized
+    # state because `allocAligned` zeroed it.
+    if not ok:
+      reset(mgr[])
+      freeAligned(mgr)
 
 proc segmentCount*[S: static int, T; MaxThreads: static int](
     self: var UnboundedSipmuc[S, T, MaxThreads]
@@ -265,14 +269,14 @@ proc getConsumer*[S: static int, T; MaxThreads: static int](
 
 # Typed destructor for retired segments. Generic over `(S, T)` so we can
 # `reset` any managed slots (`string`, `seq`, `ref`, ...) before
-# `c_free`'s away the segment block. For POD `T` (`supportsCopyMem`),
+# `freeAligned`'s away the segment block. For POD `T` (`supportsCopyMem`),
 # the loop is compile-time-elided.
 proc segmentDestructor[S: static int, T](p: pointer) {.nimcall, raises: [].} =
   when not supportsCopyMem(T):
     let seg = cast[ptr Segment[S, T]](p)
     for i in 0 ..< S:
       reset(seg.data[i])
-  c_free(p)
+  freeAligned(p)
 
 proc pop*[S: static int, T; MaxThreads: static int](
     self: var Consumer[S, T, MaxThreads]
@@ -396,12 +400,12 @@ proc `=destroy`*[S: static int, T; MaxThreads: static int](
   while seg != nil:
     when not supportsCopyMem(T):
       # Run the destructor for any managed slots (string/seq/ref) before
-      # `c_free`'s away the segment block — otherwise their internal
+      # `freeAligned`'s away the segment block — otherwise their internal
       # allocations leak.
       for i in 0 ..< S:
         reset(seg.data[i])
     let next = seg.next.load(moRelaxed)
-    c_free(seg)
+    freeAligned(seg)
     seg = next
 
   # Release our refcount on the manager. Conceptually pairs with the
@@ -415,4 +419,4 @@ proc `=destroy`*[S: static int, T; MaxThreads: static int](
       # without the parsing surprise of the backtick form, which trips
       # `expr(nkIdent); unknown node kind` inside a generic destructor.
       reset(self.manager[])
-      c_free(self.manager)
+      freeAligned(self.manager)

--- a/src/lockfreequeues/unbounded_sipsic.nim
+++ b/src/lockfreequeues/unbounded_sipsic.nim
@@ -184,6 +184,21 @@ proc pop*[S: static int, T](
     return none(seq[T])
   return some(items)
 
+when defined(testing):
+  proc headSegmentForTest*[S: static int, T](
+      self: var UnboundedSipsic[S, T]
+  ): pointer =
+    ## Test-only accessor: returns the queue's current head segment pointer
+    ## so the cache-line padding audit can verify base alignment.
+    result = cast[pointer](self.headSegment.load(moRelaxed))
+
+  proc segmentHeadOffsetForTest*[S: static int, T](
+      _: typedesc[UnboundedSipsic[S, T]]
+  ): tuple[head: int, tail: int] =
+    ## Test-only accessor: returns offsets of cache-line-padded fields within
+    ## the unbounded sipsic Segment for the cache-line padding audit.
+    result = (offsetOf(Segment[S, T], head), offsetOf(Segment[S, T], tail))
+
 proc `=destroy`*[S: static int, T](self: var UnboundedSipsic[S, T]) =
   ## Clean up all segments.
   var seg = self.headSegment.load(moRelaxed)

--- a/src/lockfreequeues/unbounded_sipsic.nim
+++ b/src/lockfreequeues/unbounded_sipsic.nim
@@ -19,7 +19,6 @@ import ./atomic_dsl
 import ./internal/aligned_alloc
 import std/options
 import std/typetraits
-from system/ansi_c import c_free
 
 type
   Segment*[S: static int, T] = object
@@ -164,7 +163,7 @@ proc pop*[S: static int, T](self: var UnboundedSipsic[S, T]): Option[T] =
     self.headSegment.store(nextSeg, moRelease)
     seg = nextSeg
     discard self.segments.fetchSub(1, moRelaxed)
-    c_free(oldSeg)
+    freeAligned(oldSeg)
 
 proc pop*[S: static int, T](
     self: var UnboundedSipsic[S, T], count: int
@@ -209,9 +208,9 @@ proc `=destroy`*[S: static int, T](self: var UnboundedSipsic[S, T]) =
     let next = seg.next.load(moRelaxed)
     when not supportsCopyMem(T):
       # Run the destructor for any managed slots (string/seq/ref) before
-      # `c_free`'s away the segment block — otherwise their internal
+      # `freeAligned`'s away the segment block — otherwise their internal
       # allocations leak.
       for i in 0 ..< S:
         reset(seg.data[i])
-    c_free(seg)
+    freeAligned(seg)
     seg = next

--- a/src/lockfreequeues/unbounded_sipsic.nim
+++ b/src/lockfreequeues/unbounded_sipsic.nim
@@ -16,32 +16,35 @@
 ## ```
 
 import ./atomic_dsl
+import ./internal/aligned_alloc
 import std/options
 import std/typetraits
-from system/ansi_c import c_calloc, c_free
+from system/ansi_c import c_free
 
 type
   Segment*[S: static int, T] = object
     data*: array[S, T]
-    next*: Atomic[ptr Segment[S, T]]
-    head*: Atomic[int]
-    tail*: Atomic[int]
+    next* {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+    head* {.align: CacheLineBytes.}: Atomic[int]
+    tail* {.align: CacheLineBytes.}: Atomic[int]
 
   UnboundedSipsic*[S: static int, T] = object
     ## Unbounded SPSC queue using linked segments.
     ##
     ## - S: Segment size (compile-time constant).
     ## - T: Data type.
-    headSegment: Atomic[ptr Segment[S, T]] # Consumer reads from here
-    tailSegment: Atomic[ptr Segment[S, T]] # Producer writes here
+    headSegment {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+      # Consumer reads from here
+    tailSegment {.align: CacheLineBytes.}: Atomic[ptr Segment[S, T]]
+      # Producer writes here
     itemCount: Atomic[int] # Total items in queue
     segments: Atomic[int] # Number of segments
 
 proc newSegment[S: static int, T](): ptr Segment[S, T] =
-  ## Allocate a new segment via libc calloc (zero-initialized, truly shared).
-  result = cast[ptr Segment[S, T]](c_calloc(1.csize_t, sizeof(Segment[S, T]).csize_t))
-  if result == nil:
-    raise newException(OutOfMemDefect, "newSegment: c_calloc returned nil")
+  ## Allocate a new segment on a CacheLineBytes boundary so the
+  ## ``{.align.}`` pragmas above land on distinct physical cache lines
+  ## rather than sharing the 16-byte-aligned base that ``c_calloc`` returns.
+  result = allocAligned[Segment[S, T]]()
   result.next.store(nil, moRelaxed)
   result.head.store(0, moRelaxed)
   result.tail.store(0, moRelaxed)

--- a/tests/t_aligned_alloc.nim
+++ b/tests/t_aligned_alloc.nim
@@ -1,0 +1,60 @@
+## Unit tests for ``internal/aligned_alloc.nim``.
+##
+## Verifies that ``allocAligned[T]`` returns ``CacheLineBytes``-aligned,
+## zero-initialized memory across a range of payload sizes (struct under,
+## equal-to, and over a single cache line).
+
+import lockfreequeues/atomic_dsl
+import lockfreequeues/internal/aligned_alloc
+import unittest2
+from system/ansi_c import c_free
+
+type
+  Tiny = object
+    a: int
+
+  Line = object
+    a: int
+    b: int
+    c: int
+    d: int
+    e: int
+    f: int
+    g: int
+    h: int
+
+  Big = object
+    a: array[256, byte]
+
+suite "internal/aligned_alloc.allocAligned":
+  test "tiny payload (sizeof < CacheLineBytes) is 64B-aligned":
+    let p = allocAligned[Tiny]()
+    check p != nil
+    check (cast[uint](p) mod CacheLineBytes.uint) == 0
+    check p.a == 0 # zero-initialized
+    c_free(p)
+
+  test "line-sized payload (sizeof == CacheLineBytes) is 64B-aligned":
+    let p = allocAligned[Line]()
+    check p != nil
+    check (cast[uint](p) mod CacheLineBytes.uint) == 0
+    check p.a == 0
+    check p.h == 0
+    c_free(p)
+
+  test "big payload (sizeof > CacheLineBytes) is 64B-aligned":
+    let p = allocAligned[Big]()
+    check p != nil
+    check (cast[uint](p) mod CacheLineBytes.uint) == 0
+    for i in 0 ..< 256:
+      check p.a[i] == 0.byte
+    c_free(p)
+
+  test "many allocations are all 64B-aligned":
+    var ptrs: array[64, ptr Line]
+    for i in 0 ..< 64:
+      ptrs[i] = allocAligned[Line]()
+      check ptrs[i] != nil
+      check (cast[uint](ptrs[i]) mod CacheLineBytes.uint) == 0
+    for i in 0 ..< 64:
+      c_free(ptrs[i])

--- a/tests/t_bench_adapters.nim
+++ b/tests/t_bench_adapters.nim
@@ -65,3 +65,15 @@ when defined(adapter_boost_lockfree_queue_available):
           makeBoostLockfreeQueueAdapter[uint64](capacity = 4096),
           cleanup(adapter)
         )
+
+when defined(adapter_boost_lockfree_spsc_available):
+  when defined(cpp):
+    import ../benchmarks/nim/adapters/boost_lockfree_spsc_adapter
+    import ../benchmarks/nim/adapter
+
+    suite "boost_lockfree_spsc_adapter":
+      test "push/pop 1000 uint64 round-trip preserves set":
+        runRoundTrip[BoostLockfreeSpscAdapter[uint64]](
+          makeBoostLockfreeSpscAdapter[uint64](capacity = 4096),
+          cleanup(adapter)
+        )

--- a/tests/t_bench_adapters.nim
+++ b/tests/t_bench_adapters.nim
@@ -77,3 +77,25 @@ when defined(adapter_boost_lockfree_spsc_available):
           makeBoostLockfreeSpscAdapter[uint64](capacity = 4096),
           cleanup(adapter)
         )
+
+when defined(adapter_crossbeam_array_queue_available):
+  import ../benchmarks/nim/adapters/crossbeam_array_queue_adapter
+  import ../benchmarks/nim/adapter
+
+  suite "crossbeam_array_queue_adapter":
+    test "push/pop 1000 uint64 round-trip preserves set":
+      runRoundTrip[CrossbeamArrayQueueAdapter[uint64]](
+        makeCrossbeamArrayQueueAdapter[uint64](capacity = 4096),
+        cleanup(adapter)
+      )
+
+when defined(adapter_crossbeam_seg_queue_available):
+  import ../benchmarks/nim/adapters/crossbeam_seg_queue_adapter
+  import ../benchmarks/nim/adapter
+
+  suite "crossbeam_seg_queue_adapter":
+    test "push/pop 1000 uint64 round-trip preserves set":
+      runRoundTrip[CrossbeamSegQueueAdapter[uint64]](
+        makeCrossbeamSegQueueAdapter[uint64](),
+        cleanup(adapter)
+      )

--- a/tests/t_bench_adapters.nim
+++ b/tests/t_bench_adapters.nim
@@ -49,3 +49,19 @@ when defined(adapter_loony_available):
       runRoundTrip[LoonyAdapter[uint64]](
         makeLoonyAdapter[uint64](), cleanup(adapter)
       )
+
+when defined(adapter_boost_lockfree_queue_available):
+  # Boost.LockFree is C++ -- only loadable under `nim cpp`. The adapter
+  # raises a hard {.error.} under `nim c`, so pulling it in only when both
+  # the gate AND the cpp build mode are set keeps `nim c -r` of this file
+  # compilable.
+  when defined(cpp):
+    import ../benchmarks/nim/adapters/boost_lockfree_queue_adapter
+    import ../benchmarks/nim/adapter
+
+    suite "boost_lockfree_queue_adapter":
+      test "push/pop 1000 uint64 round-trip preserves set":
+        runRoundTrip[BoostLockfreeQueueAdapter[uint64]](
+          makeBoostLockfreeQueueAdapter[uint64](capacity = 4096),
+          cleanup(adapter)
+        )

--- a/tests/t_bench_adapters.nim
+++ b/tests/t_bench_adapters.nim
@@ -1,0 +1,51 @@
+## Compile-time-gated unit tests for the comparison-MVP bench adapters.
+##
+## Each adapter is wrapped in a ``when defined(adapter_<lib>_available):``
+## block so the same test file:
+## - vacuously passes when no FFI gates are set (CI default for the
+##   in-tree-only test suite).
+## - exercises each adapter's push/pop round-trip when its ``-d`` gate is set.
+##
+## Pattern: push 1000 sequential ``uint64`` values at the smallest topology
+## the adapter supports; pop until the queue is empty; assert count + set
+## equality.
+
+import std/sets
+import unittest2
+
+const SampleCount = 1000
+
+template runRoundTrip[A](
+    makeAdapterExpr: untyped, cleanupExpr: untyped
+): untyped =
+  ## Run a SampleCount-item ``uint64`` push-then-pop round-trip on ``adapter``.
+  ## Asserts count match and set equality with the input range.
+  block:
+    var adapter {.inject.}: A = makeAdapterExpr
+    defer:
+      cleanupExpr
+    var pushed: HashSet[uint64]
+    var popped: HashSet[uint64]
+    for i in 0'u64 ..< SampleCount.uint64:
+      let r = adapter.push(i)
+      check r == prSuccess
+      pushed.incl(i)
+    var got = 0
+    while got < SampleCount:
+      let r = adapter.pop()
+      if not r.success:
+        break
+      popped.incl(r.value)
+      inc got
+    check got == SampleCount
+    check pushed == popped
+
+when defined(adapter_loony_available):
+  import ../benchmarks/nim/adapters/loony_adapter
+  import ../benchmarks/nim/adapter
+
+  suite "loony_adapter":
+    test "push/pop 1000 uint64 round-trip preserves set":
+      runRoundTrip[LoonyAdapter[uint64]](
+        makeLoonyAdapter[uint64](), cleanup(adapter)
+      )

--- a/tests/t_unbounded_padding.nim
+++ b/tests/t_unbounded_padding.nim
@@ -41,6 +41,7 @@ suite "Unbounded queue Segment cache-line padding":
   test "Segment field offsets are CacheLineBytes-aligned (mupsic)":
     let off = segmentHeadOffsetForTest(UnboundedMupsic[64, uint64, 4])
     check off.tail mod Cl == 0
+    check off.head mod Cl == 0
     check off.committed mod Cl == 0
 
   test "Segment field offsets are CacheLineBytes-aligned (mupmuc)":

--- a/tests/t_unbounded_padding.nim
+++ b/tests/t_unbounded_padding.nim
@@ -1,0 +1,78 @@
+## Cache-line padding audit for unbounded queue Segments.
+##
+## Verifies two conditions per design doc §4.2:
+## 1. Per-Segment cache-line-padded fields have field offsets that are
+##    multiples of ``CacheLineBytes``.
+## 2. ``cast[uint](segPtr) mod CacheLineBytes == 0`` for a freshly-allocated
+##    Segment via the queue's allocator (base alignment).
+##
+## RED state (Task 3.1): condition 2 fails because ``c_calloc`` returns
+## 16-byte-aligned memory on x86_64 Linux glibc. Condition 1 also fails
+## today because Segment fields lack ``{.align: CacheLineBytes.}``.
+##
+## GREEN state (Tasks 3.2–3.3): both conditions hold for all four
+## unbounded variants. ``posix_memalign`` is used to lift the segment base
+## onto a 64-byte boundary, and ``{.align: CacheLineBytes.}`` is added to
+## each Segment field that participates in producer/consumer coordination.
+
+import lockfreequeues/atomic_dsl
+import lockfreequeues/unbounded_sipsic
+import lockfreequeues/unbounded_sipmuc
+import lockfreequeues/unbounded_mupsic
+import lockfreequeues/unbounded_mupmuc
+import debra
+import unittest2
+
+# CacheLineBytes is exported from atomic_dsl via debra/atomics.
+
+const Cl = CacheLineBytes
+
+suite "Unbounded queue Segment cache-line padding":
+  test "Segment field offsets are CacheLineBytes-aligned (sipsic)":
+    let off = segmentHeadOffsetForTest(UnboundedSipsic[64, uint64])
+    check off.head mod Cl == 0
+    check off.tail mod Cl == 0
+
+  test "Segment field offsets are CacheLineBytes-aligned (sipmuc)":
+    let off = segmentHeadOffsetForTest(UnboundedSipmuc[64, uint64, 4])
+    check off.tail mod Cl == 0
+    check off.prevConsumerIdx mod Cl == 0
+
+  test "Segment field offsets are CacheLineBytes-aligned (mupsic)":
+    let off = segmentHeadOffsetForTest(UnboundedMupsic[64, uint64, 4])
+    check off.tail mod Cl == 0
+    check off.committed mod Cl == 0
+
+  test "Segment field offsets are CacheLineBytes-aligned (mupmuc)":
+    let off = segmentHeadOffsetForTest(UnboundedMupmuc[64, uint64, 4])
+    check off.tail mod Cl == 0
+    check off.prevConsumerIdx mod Cl == 0
+    check off.committed mod Cl == 0
+
+  test "freshly-allocated Segment base is CacheLineBytes-aligned (sipsic)":
+    var q = newUnboundedSipsic[64, uint64]()
+    let segPtr = headSegmentForTest(q)
+    check segPtr != nil
+    check (cast[uint](segPtr) mod Cl.uint) == 0
+
+  test "freshly-allocated Segment base is CacheLineBytes-aligned (sipmuc)":
+    var manager = initDebraManager[4]()
+    var q = newUnboundedSipmuc[64, uint64, 4](addr manager)
+    let segPtr = headSegmentForTest(q)
+    check segPtr != nil
+    check (cast[uint](segPtr) mod Cl.uint) == 0
+
+  test "freshly-allocated Segment base is CacheLineBytes-aligned (mupsic)":
+    var manager = initDebraManager[4]()
+    let consumerHandle = registerThread(manager)
+    var q = newUnboundedMupsic[64, uint64, 4](addr manager, consumerHandle)
+    let segPtr = headSegmentForTest(q)
+    check segPtr != nil
+    check (cast[uint](segPtr) mod Cl.uint) == 0
+
+  test "freshly-allocated Segment base is CacheLineBytes-aligned (mupmuc)":
+    var manager = initDebraManager[4]()
+    var q = newUnboundedMupmuc[64, uint64, 4](addr manager)
+    let segPtr = headSegmentForTest(q)
+    check segPtr != nil
+    check (cast[uint](segPtr) mod Cl.uint) == 0

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -1,3 +1,4 @@
+import ./t_aligned_alloc
 import ./t_atomic_dsl
 import ./t_backoff
 import ./t_mupmuc
@@ -23,6 +24,7 @@ import ./t_unbounded_auto_create
 import ./t_wraparound
 
 export
+  t_aligned_alloc,
   t_atomic_dsl,
   t_backoff,
   t_mupmuc,

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -13,6 +13,7 @@ import ./t_unbounded_mupmuc
 import ./t_unbounded_mupmuc_threaded
 import ./t_unbounded_mupsic
 import ./t_unbounded_mupsic_threaded
+import ./t_unbounded_padding
 import ./t_unbounded_sipmuc
 import ./t_unbounded_sipmuc_threaded
 import ./t_unbounded_sipsic
@@ -37,6 +38,7 @@ export
   t_unbounded_mupmuc_threaded,
   t_unbounded_mupsic,
   t_unbounded_mupsic_threaded,
+  t_unbounded_padding,
   t_unbounded_sipmuc,
   t_unbounded_sipmuc_threaded,
   t_unbounded_sipsic,


### PR DESCRIPTION
Depends on PR #19, PR #20, PR #21.

## Summary

Track 3 (Comparison MVP) of the bench-rollup feature. Adds five third-party adapters so each topology has at least three distinct libraries plotted on the same Bencher dashboard, plus the cache-line padding fix flagged by design §4.2.

## What's in this PR

### Comparison MVP adapters (Track 3 §3.5–3.10)

| Library | Variant | Topology | Compile gate |
|---------|---------|----------|--------------|
| Loony | `LoonyQueue` | `mpmc_unbounded` | `-d:adapter_loony_available` |
| Boost.LockFree | `boost::lockfree::queue` | `mpmc` (bounded) | `-d:adapter_boost_lockfree_queue_available` (requires `nim cpp`) |
| Boost.LockFree | `boost::lockfree::spsc_queue` | `spsc` (bounded) | `-d:adapter_boost_lockfree_spsc_available` (requires `nim cpp`) |
| Crossbeam | `crossbeam_queue::ArrayQueue` | `mpmc` (bounded) | `-d:adapter_crossbeam_array_queue_available` |
| Crossbeam | `crossbeam_queue::SegQueue` | `mpmc_unbounded` | `-d:adapter_crossbeam_seg_queue_available` |

Each adapter is wrapped in `when defined(adapter_<lib>_available):` so absent gates produce zero symbol references and production builds are unchanged. Round-trip (1000-item set equality) tests are wired into `tests/t_bench_adapters.nim`, gated by the same defines.

### New Rust crate `benchmarks/rust/bench-ffi-crossbeam/`

A `cdylib` exposing 8 `extern "C"` fns wrapping `crossbeam_queue::ArrayQueue<u64>` and `crossbeam_queue::SegQueue<u64>`. `rust-toolchain.toml` pins `stable`. Six integration tests cover round-trip set equality for both queues, capacity edges, empty-pop, and null-pointer tolerance.

### CI integration

- `bench.yml` now installs Loony + Boost.LockFree on every PR via the design §2.6 soft-skip pattern (install -> smoke -> set-flag-on-success -> annotate-on-failure). `workflow_dispatch` accepts `force_skip_boost` / `force_skip_loony` boolean inputs to exercise the skip path manually.
- New `bench-comparison.yml` runs **Crossbeam** on a nightly cron (`0 4 * * *`), `workflow_dispatch`, and targeted path pushes to `devel`. It owns its own Bencher Report. **Crossbeam runs in this nightly workflow only — not in `bench.yml`** — to keep PR critical-path time unchanged.

### Cache-line padding audit (Track 3 §3.1–3.3)

The four unbounded queue variants previously allocated segments via `c_calloc` (16-byte ABI alignment). Now allocated via `posix_memalign` through the new `src/lockfreequeues/internal/aligned_alloc.nim` helper, with `{.align: CacheLineBytes.}` on per-segment Atomic fields. Verified by `tests/t_unbounded_padding.nim` (8 assertions across 4 variants, green under c/cpp/arc/refc).

### Documentation

- New `THIRD_PARTY_LICENSES.md` records license obligations for the comparison MVP libraries (Loony MIT, Boost BSL-1.0, Crossbeam Apache-2.0 OR MIT) with placeholder slots for concurrentqueue (PR 4) and uPlot (PR 5).
- `benchmarks/README.md` gains a "Comparison MVP" subsection with library/topology/install table and per-adapter local-run snippets.
- `CHANGELOG.md` `[Unreleased]` updated with Added (5 adapters, Rust crate, smoke binaries, bench-comparison.yml, soft-skip flow, THIRD_PARTY_LICENSES, aligned_alloc) and Fixed (cache-line padding for unbounded segments).

## Verification

- `nimble test` -> 200 OK / 0 FAILED / 0 SKIPPED.
- `cargo test --release` on the Rust crate -> 6 passed.
- `actionlint` clean on both `bench.yml` and `bench-comparison.yml`.
- `t_bench_adapters.nim` exercises Crossbeam ArrayQueue + SegQueue locally (Cargo + cdylib available); Loony and Boost are gated and skip vacuously without their respective installs.