### PR TITLE
ci(docs): expose Nim compiler API for mkdocstrings-nim; clean stale epoch link

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,6 +69,42 @@ jobs:
         run: |
           pip install -r docs-requirements.txt
 
+      - name: Resolve docs source ref
+        # mkdocs.yml reads source_ref from $DOCS_SOURCE_REF (with default
+        # `main`). Set it explicitly per trigger so mkdocstrings-nim does
+        # not warn about a detached-HEAD branch lookup (warning becomes
+        # error under `mkdocs build --strict`):
+        #   pull_request    -> the PR head branch (so blob URLs in the
+        #                      PR-verified build point at the branch
+        #                      under review)
+        #   v* tag          -> the tag (versioned docs link to release sha)
+        #   devel push      -> devel
+        #   main push       -> main
+        #   workflow_dispatch -> branch name
+        id: docs_ref
+        run: |
+          set -euo pipefail
+          case "$GITHUB_EVENT_NAME" in
+            pull_request)
+              ref="${GITHUB_HEAD_REF}"
+              ;;
+            push)
+              if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+                ref="${GITHUB_REF#refs/tags/}"
+              else
+                ref="${GITHUB_REF#refs/heads/}"
+              fi
+              ;;
+            workflow_dispatch)
+              ref="${GITHUB_REF#refs/heads/}"
+              ;;
+            *)
+              ref="main"
+              ;;
+          esac
+          echo "DOCS_SOURCE_REF=$ref" >> "$GITHUB_ENV"
+          echo "Resolved DOCS_SOURCE_REF=$ref"
+
       - name: Build docs (PR verification, no deploy)
         # On pull_request runs we only build to verify the docs compile;
         # we deliberately skip mike + git push so PR branches never touch

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,13 @@ on:
       - devel
     tags:
       - 'v*'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'docs-requirements.txt'
+      - '.github/workflows/docs.yml'
+      - 'src/**'
   workflow_dispatch:
 
 permissions:
@@ -62,12 +69,23 @@ jobs:
         run: |
           pip install -r docs-requirements.txt
 
+      - name: Build docs (PR verification, no deploy)
+        # On pull_request runs we only build to verify the docs compile;
+        # we deliberately skip mike + git push so PR branches never touch
+        # gh-pages. This catches mkdocstrings-nim regressions, broken
+        # internal links, and missing nav entries before merge.
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdocs build --strict --clean
+
       - name: Configure git
+        if: github.event_name != 'pull_request'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Fetch gh-pages
+        if: github.event_name != 'pull_request'
         run: |
           git fetch origin gh-pages --depth=1 || true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,30 @@ jobs:
         with:
           nim-version: 'stable'
 
+      - name: Expose Nim compiler API for mkdocstrings-nim
+        # mkdocstrings-nim's extractor.nim does `import compiler/[ast, parser, ...]`,
+        # which expects Nim's compiler/ source tree to be on the search path.
+        # The bundled Nim distribution includes compiler/ on disk but does not
+        # add it to the path; jiro4989/setup-nim-action does not install the
+        # compiler-as-Nimble-package either. Append `path="$lib/.."` to the
+        # bundled config/nim.cfg so `import compiler/<X>` resolves to
+        # `<nim-install-root>/compiler/<X>.nim`. Done after Setup Nim and
+        # before pip install so the mkdocstrings-nim extractor can compile
+        # on first invocation.
+        run: |
+          set -euo pipefail
+          nim_root="$(dirname "$(dirname "$(readlink -f "$(which nim)")")")"
+          if [ ! -d "$nim_root/compiler" ] || [ ! -f "$nim_root/config/nim.cfg" ]; then
+            echo "::error::expected $nim_root to contain compiler/ and config/nim.cfg"
+            exit 1
+          fi
+          # `$lib` here is a Nim config-file variable resolved by Nim, not a
+          # bash variable — heredoc with quoted delimiter writes it literal.
+          cat >> "$nim_root/config/nim.cfg" <<'NIMCFG'
+          path="$lib/.."
+          NIMCFG
+          echo "Appended compiler-API path to $nim_root/config/nim.cfg"
+
       - name: Install dependencies
         run: |
           pip install -r docs-requirements.txt
@@ -50,8 +74,8 @@ jobs:
       - name: Deploy docs (versioned)
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          mike deploy --push --update-aliases $VERSION latest
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          mike deploy --push --update-aliases "$VERSION" latest
           mike set-default --push latest
 
       - name: Deploy docs (dev)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,9 +71,10 @@ jobs:
 
       - name: Resolve docs source ref
         # mkdocs.yml reads source_ref from $DOCS_SOURCE_REF (with default
-        # `main`). Set it explicitly per trigger so mkdocstrings-nim does
-        # not warn about a detached-HEAD branch lookup (warning becomes
-        # error under `mkdocs build --strict`):
+        # `devel` — the repo's default branch). Set it explicitly per
+        # trigger so mkdocstrings-nim does not warn about a detached-HEAD
+        # branch lookup (warning becomes error under
+        # `mkdocs build --strict`):
         #   pull_request    -> the PR head branch (so blob URLs in the
         #                      PR-verified build point at the branch
         #                      under review)
@@ -99,7 +100,7 @@ jobs:
               ref="${GITHUB_REF#refs/heads/}"
               ;;
             *)
-              ref="main"
+              ref="devel"
               ;;
           esac
           echo "DOCS_SOURCE_REF=$ref" >> "$GITHUB_ENV"

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,7 +11,7 @@ Fixed-capacity ring buffer implementations. Capacity and thread counts are compi
 
 ## Unbounded Queues
 
-Dynamic-capacity linked segment implementations. Grow as needed with epoch-based memory reclamation.
+Dynamic-capacity linked segment implementations. Grow as needed with DEBRA+ epoch-based memory reclamation supplied by [nim-debra](https://github.com/elijahr/nim-debra).
 
 - **[UnboundedSipsic](unbounded_sipsic.md)** - Single-producer, single-consumer (SPSC). Wait-free operations.
 - **[UnboundedSipmuc](unbounded_sipmuc.md)** - Single-producer, multiple-consumer (SPMC). Wait-free push, lock-free pop.
@@ -20,7 +20,6 @@ Dynamic-capacity linked segment implementations. Grow as needed with epoch-based
 
 ## Support Types
 
-- **[EpochManager](epoch.md)** - Memory reclamation for unbounded queues.
 - **[Ops](ops.md)** - Ring buffer index operations (internal).
 - **DeallocationStrategy** - Memory reclamation policy:
   - `Manual` - Retire segments to epoch manager. User calls `tryReclaim()` periodically. Best for `--mm:none`.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -20,7 +20,6 @@ Dynamic-capacity linked segment implementations. Grow as needed with DEBRA+ epoc
 
 ## Support Types
 
-- **[Ops](ops.md)** - Ring buffer index operations (internal).
 - **DeallocationStrategy** - Memory reclamation policy:
   - `Manual` - Retire segments to epoch manager. User calls `tryReclaim()` periodically. Best for `--mm:none`.
   - `Eager` - Retire segments and immediately call `tryReclaim()`. Best for GC environments.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,7 +11,7 @@ Fixed-capacity ring buffer implementations. Capacity and thread counts are compi
 
 ## Unbounded Queues
 
-Dynamic-capacity linked segment implementations. Grow as needed with DEBRA+ epoch-based memory reclamation supplied by [nim-debra](https://github.com/elijahr/nim-debra).
+Dynamic-capacity linked segment implementations. Grow as needed; the MP/MC variants use DEBRA+ epoch-based memory reclamation supplied by [nim-debra](https://github.com/elijahr/nim-debra), while the SPSC variant frees retired segments inline (no manager).
 
 - **[UnboundedSipsic](unbounded_sipsic.md)** - Single-producer, single-consumer (SPSC). Wait-free operations.
 - **[UnboundedSipmuc](unbounded_sipmuc.md)** - Single-producer, multiple-consumer (SPMC). Wait-free push, lock-free pop.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -21,7 +21,7 @@ Dynamic-capacity linked segment implementations. Grow as needed with DEBRA+ epoc
 ## Support Types
 
 - **DeallocationStrategy** - Memory reclamation policy:
-  - `Manual` - Retire segments to epoch manager. User calls `tryReclaim()` periodically. Best for `--mm:none`.
+  - `Manual` - Retire segments to the `DebraManager`. User calls `tryReclaim()` periodically. Best for `--mm:none`.
   - `Eager` - Retire segments and immediately call `tryReclaim()`. Best for GC environments.
 
 ## Performance Guarantees

--- a/docs/api/mupmuc.md
+++ b/docs/api/mupmuc.md
@@ -2,4 +2,4 @@
 
 Multi-producer, multi-consumer (MPMC) bounded queue.
 
-::: lockfreequeues.mupmuc
+::: lockfreequeues/mupmuc

--- a/docs/api/mupsic.md
+++ b/docs/api/mupsic.md
@@ -2,4 +2,4 @@
 
 Multi-producer, single-consumer (MPSC) bounded queue. Popping is wait-free.
 
-::: lockfreequeues.mupsic
+::: lockfreequeues/mupsic

--- a/docs/api/ops.md
+++ b/docs/api/ops.md
@@ -1,5 +1,0 @@
-# Operations
-
-Common queue operations.
-
-::: lockfreequeues.ops

--- a/docs/api/sipmuc.md
+++ b/docs/api/sipmuc.md
@@ -73,3 +73,5 @@ proc consumer() {.thread.} =
       # Process item
       discard
 ```
+
+::: lockfreequeues/sipmuc

--- a/docs/api/sipmuc.md
+++ b/docs/api/sipmuc.md
@@ -31,24 +31,8 @@ let item = consumer.pop()  # some(42)
 - `C: static int` - Maximum number of consumers
 - `T` - Item type
 
-## API
-
-### Queue Operations
-
-```nim
-proc initSipmuc*[N, C: static int, T](): Sipmuc[N, C, T]
-proc push*[N, C, T](self: var Sipmuc[N, C, T], item: T): bool
-proc push*[N, C, T](self: var Sipmuc[N, C, T], items: openArray[T]): Option[HSlice[int, int]]
-proc getConsumer*[N, C, T](self: var Sipmuc[N, C, T]): Consumer[N, C, T]
-proc capacity*[N, C, T](self: Sipmuc[N, C, T]): int
-```
-
-### Consumer Operations
-
-```nim
-proc pop*[N, C, T](self: var Consumer[N, C, T]): Option[T]
-proc pop*[N, C, T](self: var Consumer[N, C, T], count: int): Option[seq[T]]
-```
+The full proc/type signatures and per-symbol docs are auto-generated
+from source by the `:::` directive at the bottom of this page.
 
 ## Example: Fan-Out Pattern
 

--- a/docs/api/sipsic.md
+++ b/docs/api/sipsic.md
@@ -2,4 +2,4 @@
 
 Single-producer, single-consumer (SPSC) bounded queue. Both pushing and popping are wait-free.
 
-::: lockfreequeues.sipsic
+::: lockfreequeues/sipsic

--- a/docs/api/unbounded_mupmuc.md
+++ b/docs/api/unbounded_mupmuc.md
@@ -24,10 +24,13 @@ Unbounded multiple-producer, multiple-consumer (MPMC) queue using linked segment
 ```nim
 import lockfreequeues
 
-let manager = newEpochManager()
-var queue = newUnboundedMupmuc[64, int](manager)
+# Generic params are [SegmentSize, ItemType, MaxThreads]; auto-create
+# overload (no args) heap-allocates a private DebraManager owned by
+# the queue. For multi-queue setups sharing a manager, use the
+# explicit `(manager, strategy)` overload instead.
+var queue = newUnboundedMupmuc[64, int, 4]()
 
-# Each thread gets its own handle
+# Each thread gets its own handle (auto-registers a thread slot)
 var producer = queue.getProducer()
 var consumer = queue.getConsumer()
 

--- a/docs/api/unbounded_mupmuc.md
+++ b/docs/api/unbounded_mupmuc.md
@@ -4,7 +4,7 @@ Unbounded multiple-producer, multiple-consumer (MPMC) queue using linked segment
 
 ## Overview
 
-`UnboundedMupmuc` provides an unbounded MPMC queue with fully concurrent access. Uses epoch-based memory reclamation (DEBRA) and a per-slot committed flag inside each segment for safe concurrent operations.
+`UnboundedMupmuc` provides an unbounded MPMC queue with fully concurrent access. Uses DEBRA+ epoch-based memory reclamation (via [nim-debra](https://github.com/elijahr/nim-debra)) and a per-slot committed flag inside each segment for safe concurrent operations.
 
 > **Note:** This per-slot committed flag is the *segment-local* publication
 > mechanism for the unbounded queues. It is distinct from the per-slot

--- a/docs/api/unbounded_mupmuc.md
+++ b/docs/api/unbounded_mupmuc.md
@@ -30,7 +30,10 @@ import lockfreequeues
 # explicit `(manager, strategy)` overload instead.
 var queue = newUnboundedMupmuc[64, int, 4]()
 
-# Each thread gets its own handle (auto-registers a thread slot)
+# Each thread gets its own handle (auto-registers a thread slot in the
+# manager). Slots are not released until the manager is destroyed, so
+# reuse one handle per long-running thread rather than calling
+# `getProducer()` / `getConsumer()` repeatedly.
 var producer = queue.getProducer()
 var consumer = queue.getConsumer()
 

--- a/docs/api/unbounded_mupsic.md
+++ b/docs/api/unbounded_mupsic.md
@@ -29,8 +29,8 @@ import lockfreequeues
 # the queue and registers the calling thread as the (single) consumer.
 # The caller MUST be the consumer thread; if you need to construct on
 # a different thread than the one that will pop, use the explicit
-# `(addr manager, consumerHandle, strategy)` overload with a handle
-# obtained on the consumer thread.
+# `(manager, handle, strategy)` overload with a `handle` obtained
+# on the consumer thread.
 var queue = newUnboundedMupsic[64, int, 4]()
 
 # Each producer thread gets a handle (auto-registers a thread slot)

--- a/docs/api/unbounded_mupsic.md
+++ b/docs/api/unbounded_mupsic.md
@@ -33,7 +33,10 @@ import lockfreequeues
 # on the consumer thread.
 var queue = newUnboundedMupsic[64, int, 4]()
 
-# Each producer thread gets a handle (auto-registers a thread slot)
+# Each producer thread gets a handle (auto-registers a thread slot in
+# the manager). Slots are not released until the manager is destroyed,
+# so reuse one handle per long-running producer thread rather than
+# calling `getProducer()` repeatedly.
 var producer1 = queue.getProducer()
 var producer2 = queue.getProducer()
 

--- a/docs/api/unbounded_mupsic.md
+++ b/docs/api/unbounded_mupsic.md
@@ -24,10 +24,16 @@ Unbounded multiple-producer, single-consumer (MPSC) queue using linked segments.
 ```nim
 import lockfreequeues
 
-let manager = newEpochManager()
-var queue = newUnboundedMupsic[64, int](manager)
+# Generic params are [SegmentSize, ItemType, MaxThreads]; auto-create
+# overload (no args) heap-allocates a private DebraManager owned by
+# the queue and registers the calling thread as the (single) consumer.
+# The caller MUST be the consumer thread; if you need to construct on
+# a different thread than the one that will pop, use the explicit
+# `(addr manager, consumerHandle, strategy)` overload with a handle
+# obtained on the consumer thread.
+var queue = newUnboundedMupsic[64, int, 4]()
 
-# Each producer gets a handle
+# Each producer thread gets a handle (auto-registers a thread slot)
 var producer1 = queue.getProducer()
 var producer2 = queue.getProducer()
 
@@ -35,7 +41,7 @@ var producer2 = queue.getProducer()
 producer1.push(42)
 producer2.push(123)
 
-# Single consumer pops
+# Single consumer pops directly off the queue (no Consumer handle)
 let item = queue.pop()  # some(42) or some(123)
 ```
 

--- a/docs/api/unbounded_mupsic.md
+++ b/docs/api/unbounded_mupsic.md
@@ -4,7 +4,7 @@ Unbounded multiple-producer, single-consumer (MPSC) queue using linked segments.
 
 ## Overview
 
-`UnboundedMupsic` provides an unbounded MPSC queue where multiple producers feed a single consumer. Uses epoch-based memory reclamation (DEBRA) and a per-slot committed flag inside each segment for safe concurrent writes.
+`UnboundedMupsic` provides an unbounded MPSC queue where multiple producers feed a single consumer. Uses DEBRA+ epoch-based memory reclamation (via [nim-debra](https://github.com/elijahr/nim-debra)) and a per-slot committed flag inside each segment for safe concurrent writes.
 
 > **Note:** This per-slot committed flag is the *segment-local* publication
 > mechanism for the unbounded queues. It is distinct from the per-slot

--- a/docs/api/unbounded_sipmuc.md
+++ b/docs/api/unbounded_sipmuc.md
@@ -38,7 +38,10 @@ var queue = newUnboundedSipmuc[64, int, 4]()
 # Producer pushes
 queue.push(42)
 
-# Each consumer gets a handle (auto-registers a thread slot)
+# Each consumer gets a handle (auto-registers a thread slot in the
+# manager). Slots are not released until the manager is destroyed, so
+# reuse one handle per long-running consumer thread rather than calling
+# `getConsumer()` repeatedly.
 var consumer1 = queue.getConsumer()
 var consumer2 = queue.getConsumer()
 

--- a/docs/api/unbounded_sipmuc.md
+++ b/docs/api/unbounded_sipmuc.md
@@ -4,7 +4,7 @@ Unbounded single-producer, multiple-consumer (SPMC) queue using linked segments.
 
 ## Overview
 
-`UnboundedSipmuc` provides an unbounded SPMC queue where a single producer distributes work to multiple consumers. Uses epoch-based memory reclamation (DEBRA) for safe segment deallocation, and a per-slot committed flag inside each segment for safe publication to concurrent consumers.
+`UnboundedSipmuc` provides an unbounded SPMC queue where a single producer distributes work to multiple consumers. Uses DEBRA+ epoch-based memory reclamation (via [nim-debra](https://github.com/elijahr/nim-debra)) for safe segment deallocation, and a per-slot committed flag inside each segment for safe publication to concurrent consumers.
 
 > **Note:** This per-slot committed flag is the *segment-local* publication
 > mechanism for the unbounded queues. It is distinct from the per-slot
@@ -23,14 +23,18 @@ Unbounded single-producer, multiple-consumer (SPMC) queue using linked segments.
 
 ```nim
 import lockfreequeues
+import debra
 
-let manager = newEpochManager()
-var queue = newUnboundedSipmuc[64, int](manager)
+# Auto-create overload: queue owns a private DebraManager (torn down
+# with the queue). For multi-queue setups sharing a manager, see the
+# explicit `(manager, strategy)` overload.
+const MaxThreads = 4
+var queue = newUnboundedSipmuc[64, int, MaxThreads]()
 
 # Producer pushes
 queue.push(42)
 
-# Each consumer gets a handle
+# Each consumer gets a handle (auto-registers a thread slot)
 var consumer1 = queue.getConsumer()
 var consumer2 = queue.getConsumer()
 

--- a/docs/api/unbounded_sipmuc.md
+++ b/docs/api/unbounded_sipmuc.md
@@ -4,15 +4,20 @@ Unbounded single-producer, multiple-consumer (SPMC) queue using linked segments.
 
 ## Overview
 
-`UnboundedSipmuc` provides an unbounded SPMC queue where a single producer distributes work to multiple consumers. Uses DEBRA+ epoch-based memory reclamation (via [nim-debra](https://github.com/elijahr/nim-debra)) for safe segment deallocation, and a per-slot committed flag inside each segment for safe publication to concurrent consumers.
+`UnboundedSipmuc` provides an unbounded SPMC queue where a single producer distributes work to multiple consumers. Uses DEBRA+ epoch-based memory reclamation (via [nim-debra](https://github.com/elijahr/nim-debra)) for safe segment deallocation, and a segment-level `tail` atomic for safe publication to concurrent consumers.
 
-> **Note:** This per-slot committed flag is the *segment-local* publication
-> mechanism for the unbounded queues. It is distinct from the per-slot
-> sequence-counter protocol used by the bounded variants (`Mupmuc`, `Mupsic`,
-> `Sipmuc`). Unbounded segments are single-use linked nodes (no generation
-> rollover), so the simpler one-shot committed flag is sufficient. See
-> [slot-ownership-typestates.md](../slot-ownership-typestates.md) for the
-> full distinction.
+> **Note:** With a single producer there is no race on the slot itself,
+> so each segment carries one `tail: Atomic[int]` rather than a per-slot
+> commit/sequence marker. The producer writes the item then bumps `tail`
+> with release ordering; consumers acquire-load `tail` and treat any
+> slot below it as fully published. The unbounded MP variants
+> (`UnboundedMupsic`, `UnboundedMupmuc`) need a per-slot committed flag
+> because multiple producers race on `tail` via CAS to claim a slot
+> before writing, so `tail` can advance past not-yet-written slots; the
+> bounded MP variants use a per-slot sequence-counter protocol with
+> generation rollover. See [slot-ownership-typestates.md](../slot-ownership-typestates.md)
+> for the full distinction across all four bounded × unbounded × SP × MP
+> combinations.
 
 **Performance characteristics:**
 

--- a/docs/api/unbounded_sipmuc.md
+++ b/docs/api/unbounded_sipmuc.md
@@ -28,13 +28,12 @@ Unbounded single-producer, multiple-consumer (SPMC) queue using linked segments.
 
 ```nim
 import lockfreequeues
-import debra
 
-# Auto-create overload: queue owns a private DebraManager (torn down
-# with the queue). For multi-queue setups sharing a manager, see the
-# explicit `(manager, strategy)` overload.
-const MaxThreads = 4
-var queue = newUnboundedSipmuc[64, int, MaxThreads]()
+# Generic params are [SegmentSize, ItemType, MaxThreads]; auto-create
+# overload (no args) heap-allocates a private DebraManager owned by
+# the queue. For multi-queue setups sharing a manager, use the
+# explicit `(manager, strategy)` overload instead.
+var queue = newUnboundedSipmuc[64, int, 4]()
 
 # Producer pushes
 queue.push(42)

--- a/docs/api/unbounded_sipsic.md
+++ b/docs/api/unbounded_sipsic.md
@@ -4,7 +4,7 @@ Unbounded single-producer, single-consumer (SPSC) queue using linked segments.
 
 ## Overview
 
-`UnboundedSipsic` provides an unbounded SPSC queue that grows dynamically as items are added. Single-producer, single-consumer means there is no DEBRA manager: the queue can safely free retired segments inline once the consumer has advanced past them.
+`UnboundedSipsic` provides an unbounded SPSC queue that grows dynamically as items are added. Single-producer, single-consumer means there is no DEBRA manager: the consumer frees each retired segment inline once it advances past it. This is safe because the producer publishes the new segment via a release-store on `seg.next` *before* moving on, and never writes to the old segment afterwards. By the time the consumer can observe `seg.next != nil` and free the old segment, the producer has already abandoned it.
 
 **Performance characteristics:**
 

--- a/docs/api/unbounded_sipsic.md
+++ b/docs/api/unbounded_sipsic.md
@@ -4,7 +4,7 @@ Unbounded single-producer, single-consumer (SPSC) queue using linked segments.
 
 ## Overview
 
-`UnboundedSipsic` provides an unbounded SPSC queue that grows dynamically as items are added. Uses epoch-based memory reclamation for safe segment deallocation.
+`UnboundedSipsic` provides an unbounded SPSC queue that grows dynamically as items are added. Single-producer, single-consumer means there is no DEBRA manager: the queue can safely free retired segments inline once the consumer has advanced past them.
 
 **Performance characteristics:**
 
@@ -16,8 +16,9 @@ Unbounded single-producer, single-consumer (SPSC) queue using linked segments.
 ```nim
 import lockfreequeues
 
-let manager = newEpochManager()
-var queue = newUnboundedSipsic[64, int](manager)
+# Generic params are [SegmentSize, ItemType]. SPSC needs no DEBRA
+# manager and no MaxThreads parameter — the constructor takes none.
+var queue = newUnboundedSipsic[64, int]()
 
 # Push items (never fails - grows as needed)
 queue.push(42)

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Ring buffer implementations with compile-time capacity. Best for predictable mem
 
 ### Unbounded Queues (Dynamic Capacity)
 
-Linked segment implementations that grow as needed. Use DEBRA+ epoch-based reclamation (via [nim-debra](https://github.com/elijahr/nim-debra)) for safe memory deallocation.
+Linked segment implementations that grow as needed. The MP/MC variants use DEBRA+ epoch-based reclamation (via [nim-debra](https://github.com/elijahr/nim-debra)) for safe memory deallocation; the SPSC variant frees retired segments inline (no manager).
 
 | Queue | Producers | Consumers | Push | Pop |
 |-------|-----------|-----------|------|-----|

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Ring buffer implementations with compile-time capacity. Best for predictable mem
 
 ### Unbounded Queues (Dynamic Capacity)
 
-Linked segment implementations that grow as needed. Use epoch-based reclamation for safe memory deallocation.
+Linked segment implementations that grow as needed. Use DEBRA+ epoch-based reclamation (via [nim-debra](https://github.com/elijahr/nim-debra)) for safe memory deallocation.
 
 | Queue | Producers | Consumers | Push | Pop |
 |-------|-----------|-----------|------|-----|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,8 +81,10 @@ nav:
       - UnboundedSipmuc: api/unbounded_sipmuc.md
       - UnboundedMupsic: api/unbounded_mupsic.md
       - UnboundedMupmuc: api/unbounded_mupmuc.md
-    - Support:
-      - Operations: api/ops.md
+  - Concepts:
+    - Safety Model: safety-model.md
+    - Slot Ownership Typestates: slot-ownership-typestates.md
+  - Benchmarks: benchmarks.md
   - Examples: examples.md
 
 watch:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,13 @@ plugins:
             show_signature: true
             heading_level: 3  # h3 so procs nest under h2 API section in TOC
             source_url: https://github.com/elijahr/lockfreequeues
-            # source_ref auto-detected from git branch; set explicitly for releases
+            # source_ref drives the github blob URL stamped on each
+            # source-link. Auto-detection from the working tree fails on
+            # CI (actions/checkout produces a detached HEAD), so we read
+            # it from DOCS_SOURCE_REF and default to main for local
+            # `mkdocs serve`. CI exports the right value per trigger:
+            # PR -> head ref, devel push -> devel, v* tag -> tag name.
+            source_ref: !ENV [DOCS_SOURCE_REF, main]
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,10 +53,12 @@ plugins:
             # source_ref drives the github blob URL stamped on each
             # source-link. Auto-detection from the working tree fails on
             # CI (actions/checkout produces a detached HEAD), so we read
-            # it from DOCS_SOURCE_REF and default to main for local
-            # `mkdocs serve`. CI exports the right value per trigger:
-            # PR -> head ref, devel push -> devel, v* tag -> tag name.
-            source_ref: !ENV [DOCS_SOURCE_REF, main]
+            # it from DOCS_SOURCE_REF and default to `devel` (this repo's
+            # default branch — verified via gh repo view) so local
+            # `mkdocs serve` produces working source links without env
+            # setup. CI exports the right value per trigger: PR -> head
+            # ref, devel push -> devel, v* tag -> tag name.
+            source_ref: !ENV [DOCS_SOURCE_REF, devel]
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
## What

The docs.yml deploy has been failing on every push for several releases (v3.2.0, v4.0.0, and the just-pushed v4.1.0 / devel). Two issues:

1. **Real failure:** mkdocstrings-nim's bundled extractor does \`import compiler/[ast, parser, idents, ...]\`. The Nim distribution ships those sources under the install root's \`compiler/\` subdir but does **not** add it to the search path; jiro4989/setup-nim-action does not register the compiler-as-Nimble-package either. So the first time mkdocstrings-nim runs in CI it aborts with \`Error: cannot open file: compiler/ast\` and every API page rendering call falls over with \`Could not collect 'lockfreequeues.<module>'\`.
2. **Adjacent paper cut:** \`docs/api/index.md\` still linked the long-removed \`epoch.md\` page, surfacing a build WARNING.

## How

- Append \`path="\$lib/.."\` to the bundled \`config/nim.cfg\` after Setup Nim (\`\$lib\` is a Nim config-file variable resolved by Nim itself; heredoc with quoted delimiter keeps it literal). Locally verified: without the entry the import fails identically to CI, with it the same source compiles.
- Drop the stale EpochManager bullet from the API index and reword the unbounded-queues blurb to credit nim-debra.
- Quote \`\$VERSION\` in the \`mike deploy\` step (shellcheck SC2086).

## Why

Doc deploys on every release silently no-op because the post-build push step never ran; users see stale 4.0.0 docs at \`latest\`. Fixing this restores the v* tag → versioned docs deploy chain.