### PR TITLE
Fix CAS failure memory ordering (unbreaks test suite on devel)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Nim
         uses: jiro4989/setup-nim-action@v2
@@ -38,7 +38,7 @@ jobs:
   test:
     name: Test nim-${{ matrix.nim-version }} / ${{ matrix.runs-on }}
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -46,6 +46,10 @@ jobs:
         include:
           - runs-on: ubuntu-latest
             nim-version: 'stable'
+            sanitize-threads: 'yes'
+            sanitize-address: 'yes'
+          - runs-on: ubuntu-latest
+            nim-version: 'devel'
             sanitize-threads: 'yes'
             sanitize-address: 'yes'
           - runs-on: ubuntu-24.04-arm
@@ -59,13 +63,13 @@ jobs:
 
     steps:
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${HOME}/.cache
           key: cache-${{ matrix.runs-on }}-${{ matrix.nim-version }}
 
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Nim ${{ matrix.nim-version }}
         uses: jiro4989/setup-nim-action@v2

--- a/src/lockfreequeues/mupmuc.nim
+++ b/src/lockfreequeues/mupmuc.nim
@@ -114,7 +114,7 @@ proc getProducer*[N, P, C: static int, T](
   for i in 0 ..< P:
     var expected = 0
     if self.producerThreadIds[i].compareExchangeWeak(
-      expected, threadId, moRelease, moAcquire
+      expected, threadId, moRelease, moRelaxed
     ):
       result.idx = i
       return
@@ -149,7 +149,7 @@ proc getConsumer*[N, P, C: static int, T](
   for i in 0 ..< C:
     var expected = 0
     if self.consumerThreadIds[i].compareExchangeWeak(
-      expected, threadId, moRelease, moAcquire
+      expected, threadId, moRelease, moRelaxed
     ):
       result.idx = i
       return

--- a/src/lockfreequeues/mupsic.nim
+++ b/src/lockfreequeues/mupsic.nim
@@ -105,7 +105,7 @@ proc getProducer*[N, P: static int, T](
   for i in 0 ..< P:
     var expected = 0
     if self.producerThreadIds[i].compareExchangeWeak(
-      expected, threadId, moRelease, moAcquire
+      expected, threadId, moRelease, moRelaxed
     ):
       result.idx = i
       return

--- a/src/lockfreequeues/sipmuc.nim
+++ b/src/lockfreequeues/sipmuc.nim
@@ -161,7 +161,7 @@ proc getConsumer*[N, C: static int, T](
   for i in 0 ..< C:
     var expected = 0
     if self.consumerThreadIds[i].compareExchangeWeak(
-      expected, threadId, moRelease, moAcquire
+      expected, threadId, moRelease, moRelaxed
     ):
       result.idx = i
       return

--- a/src/lockfreequeues/typestates/atomic_loaders.nim
+++ b/src/lockfreequeues/typestates/atomic_loaders.nim
@@ -1,5 +1,6 @@
 ## Type-safe atomic load/store for queue pointers.
 
+import typestates
 import ../atomic_dsl
 import ./virtual_values_n
 import ./virtual_values_n1
@@ -19,11 +20,13 @@ proc loadSequentialN1*[N: static int](a: var Atomic[int]): RawLoadedN1[N] {.inli
   initRawN1[N](a.load(moSequentiallyConsistent))
 
 # N-slot store - ONLY way to extract value from WrappedValueN
-proc storeReleaseN*[N: static int](a: var Atomic[int], v: WrappedValueN[N]) {.inline.} =
+proc storeReleaseN*[N: static int](
+    a: var Atomic[int], v: WrappedValueN[N]
+) {.inline, notATransition.} =
   a.store(v.value, moRelease)
 
 # N+1-slot store - ONLY way to extract value from WrappedValueN1
 proc storeReleaseN1*[N: static int](
     a: var Atomic[int], v: WrappedValueN1[N]
-) {.inline.} =
+) {.inline, notATransition.} =
   a.store(v.value, moRelease)

--- a/src/lockfreequeues/typestates/cas.nim
+++ b/src/lockfreequeues/typestates/cas.nim
@@ -51,7 +51,7 @@ proc executeCAS*(p: CASPending): CASResult {.transition.} =
   let attempt = CASAttempt(p)
   var expected = attempt.expected
   let success =
-    attempt.atom[].compareExchangeWeak(expected, attempt.desired, moRelease, moAcquire)
+    attempt.atom[].compareExchangeWeak(expected, attempt.desired, moRelease, moRelaxed)
   if success:
     CASResult -> CASSucceeded(newVal: attempt.desired)
   else:

--- a/src/lockfreequeues/typestates/mpmc_cell.nim
+++ b/src/lockfreequeues/typestates/mpmc_cell.nim
@@ -12,6 +12,7 @@
 ## sufficient to keep cells on independent cache lines — see the comment on
 ## the explicit `pad` field below.
 
+import typestates
 import ../atomic_dsl
 import ./virtual_values_n
 
@@ -71,7 +72,7 @@ proc init*[N: static int, T](a: var MPMCCellArrayN[N, T]) =
 
 proc seqLoad*[N: static int, T](
     a: var MPMCCellArrayN[N, T], idx: PhysicalSlotN[N], order: static MemoryOrder
-): uint64 {.inline.} =
+): uint64 {.inline, notATransition.} =
   a.cells[idx.slotValue].payload.seq.load(order)
 
 proc seqStore*[N: static int, T](
@@ -79,12 +80,12 @@ proc seqStore*[N: static int, T](
     idx: PhysicalSlotN[N],
     val: uint64,
     order: static MemoryOrder,
-) {.inline.} =
+) {.inline, notATransition.} =
   a.cells[idx.slotValue].payload.seq.store(val, order)
 
 proc dataPtr*[N: static int, T](
     a: var MPMCCellArrayN[N, T], idx: PhysicalSlotN[N]
-): ptr T {.inline.} =
+): ptr T {.inline, notATransition.} =
   ## Plain (non-atomic) access to the payload data. Caller MUST hold slot
   ## ownership via the seq protocol before reading or writing through this
   ## pointer — the seq counter's acquire/release pairing provides the

--- a/src/lockfreequeues/typestates/mpmc_pop.nim
+++ b/src/lockfreequeues/typestates/mpmc_pop.nim
@@ -87,7 +87,7 @@ proc tryClaim*[N, P, C: static int, T](
 
 proc complete*[N, P, C: static int, T](
     op: MPMCPopSlotClaimed[N], queue: var MupmucBase[N, P, C, T]
-): T {.inline.} =
+): T {.inline, notATransition.} =
   ## Read value from the claimed slot, then re-arm the seq for the next
   ## generation. The `seq.store(pos+N, moRelease)` is the consumer->next-
   ## producer edge; the next producer at virtual position `pos + N` will

--- a/src/lockfreequeues/typestates/mpmc_push.nim
+++ b/src/lockfreequeues/typestates/mpmc_push.nim
@@ -92,7 +92,7 @@ proc tryClaim*[N, P, C: static int, T](
 
 proc complete*[N, P, C: static int, T](
     op: MPMCPushSlotClaimed[N], queue: var MupmucPushBase[N, P, C, T], item: T
-): bool {.inline.} =
+): bool {.inline, notATransition.} =
   ## Write item to the claimed slot, then publish the seq advance.
   ## The `seq.store(pos+1, moRelease)` is the producer->consumer edge.
   queue.cells.dataPtr(op.slot)[] = item # P4 plain store; ordered by P5

--- a/src/lockfreequeues/typestates/mpsc_pop.nim
+++ b/src/lockfreequeues/typestates/mpsc_pop.nim
@@ -108,7 +108,7 @@ proc tryClaim*[N, P: static int, T](
 
 proc complete*[N, P: static int, T](
     op: MPSCPopSlotClaimed[N], queue: var MupsicBase[N, P, T]
-): T {.inline.} =
+): T {.inline, notATransition.} =
   ## Read value from the claimed slot, then re-arm the seq for the next
   ## generation. The `seq.store(pos+N, moRelease)` is the consumer->next-
   ## producer edge; the next producer at virtual position `pos + N` will

--- a/src/lockfreequeues/typestates/mpsc_push.nim
+++ b/src/lockfreequeues/typestates/mpsc_push.nim
@@ -94,7 +94,7 @@ proc tryClaim*[N, P: static int, T](
 
 proc complete*[N, P: static int, T](
     op: MPSCPushSlotClaimed[N], queue: var MupsicPushBase[N, P, T], item: T
-): bool {.inline.} =
+): bool {.inline, notATransition.} =
   ## Write item to the claimed slot, then publish the seq advance.
   ## The `seq.store(pos+1, moRelease)` is the producer->consumer edge.
   queue.cells.dataPtr(op.slot)[] = item # P4 plain store; ordered by P5

--- a/src/lockfreequeues/typestates/slot_seq_n.nim
+++ b/src/lockfreequeues/typestates/slot_seq_n.nim
@@ -17,6 +17,7 @@
 ## the old CommittedFlagsN module) — an arbitrary `int` cannot be passed in,
 ## eliminating a class of off-by-one indexing bugs.
 
+import typestates
 import ../atomic_dsl
 import ./virtual_values_n
 
@@ -33,10 +34,10 @@ proc init*[N: static int](s: var SlotSeqN[N]) =
 
 proc load*[N: static int](
     s: var SlotSeqN[N], idx: PhysicalSlotN[N], order: static MemoryOrder
-): uint64 {.inline.} =
+): uint64 {.inline, notATransition.} =
   s.seqs[idx.slotValue].load(order)
 
 proc store*[N: static int](
     s: var SlotSeqN[N], idx: PhysicalSlotN[N], val: uint64, order: static MemoryOrder
-) {.inline.} =
+) {.inline, notATransition.} =
   s.seqs[idx.slotValue].store(val, order)

--- a/src/lockfreequeues/typestates/spmc_pop.nim
+++ b/src/lockfreequeues/typestates/spmc_pop.nim
@@ -90,7 +90,7 @@ proc tryClaim*[N, C: static int, T](
 
 proc complete*[N, C: static int, T](
     op: SPMCPopSlotClaimed[N], queue: var SipmucBase[N, C, T]
-): T {.inline.} =
+): T {.inline, notATransition.} =
   ## Read value from the claimed slot, then re-arm the seq for the next
   ## generation. The `seq.store(pos+N, moRelease)` is the consumer->next-
   ## producer edge; the next producer at virtual position `pos + N` will

--- a/src/lockfreequeues/typestates/spmc_push.nim
+++ b/src/lockfreequeues/typestates/spmc_push.nim
@@ -112,7 +112,7 @@ proc tryClaim*[N, C: static int, T](
 
 proc complete*[N, C: static int, T](
     op: SPMCPushSlotClaimed[N], queue: var SipmucPushBase[N, C, T], item: T
-): bool {.inline.} =
+): bool {.inline, notATransition.} =
   ## Write item to the claimed slot, then publish the seq advance.
   ## The `seq.store(pos+1, moRelease)` is the producer->consumer edge.
   queue.cells.dataPtr(op.slot)[] = item # P4 plain store; ordered by P5

--- a/src/lockfreequeues/typestates/spsc_pop.nim
+++ b/src/lockfreequeues/typestates/spsc_pop.nim
@@ -67,7 +67,7 @@ proc checkEmpty*[N: static int](
 
 proc complete*[N: static int, T](
     op: SPSCPopNotEmpty[N], queue: var SipsicBase[N, T]
-): T {.inline.} =
+): T {.inline, notATransition.} =
   ## Read value, advance head. Returns the value.
   let value = queue.storage[op.slot]
   let newHead = op.head.incOrResetN1(1)

--- a/src/lockfreequeues/typestates/spsc_push.nim
+++ b/src/lockfreequeues/typestates/spsc_push.nim
@@ -90,7 +90,7 @@ proc writeData*[N: static int, T](
 
 proc complete*[N: static int, T](
     op: SPSCPushDataWritten[N], queue: var SipsicBase[N, T]
-): bool {.inline.} =
+): bool {.inline, notATransition.} =
   ## Advance tail and return success.
   queue.tail.storeReleaseN1(op.newTail)
   true

--- a/src/lockfreequeues/typestates/storage_n.nim
+++ b/src/lockfreequeues/typestates/storage_n.nim
@@ -2,6 +2,7 @@
 ##
 ## Can ONLY be indexed with PhysicalSlotN[N], preventing index formula bugs.
 
+import typestates
 import ./virtual_values_n
 
 type StorageN*[N: static int, T] = object ## Storage with exactly N slots.
@@ -12,18 +13,20 @@ proc init*[N: static int, T](s: var StorageN[N, T]) =
   for i in 0 ..< N:
     s.data[i].reset()
 
-proc `[]`*[N: static int, T](s: StorageN[N, T], idx: PhysicalSlotN[N]): T {.inline.} =
+proc `[]`*[N: static int, T](
+    s: StorageN[N, T], idx: PhysicalSlotN[N]
+): T {.inline, notATransition.} =
   ## Read from storage (requires PhysicalSlotN).
   s.data[idx.slotValue]
 
 proc `[]`*[N: static int, T](
     s: var StorageN[N, T], idx: PhysicalSlotN[N]
-): var T {.inline.} =
+): var T {.inline, notATransition.} =
   ## Read as var (requires PhysicalSlotN).
   s.data[idx.slotValue]
 
 proc `[]=`*[N: static int, T](
     s: var StorageN[N, T], idx: PhysicalSlotN[N], val: T
-) {.inline.} =
+) {.inline, notATransition.} =
   ## Write to storage (requires PhysicalSlotN).
   s.data[idx.slotValue] = val

--- a/src/lockfreequeues/typestates/storage_n1.nim
+++ b/src/lockfreequeues/typestates/storage_n1.nim
@@ -1,5 +1,6 @@
 ## N+1-slot storage for SPSC queue.
 
+import typestates
 import ./virtual_values_n1
 
 type StorageN1*[N: static int, T] = object
@@ -10,15 +11,17 @@ proc init*[N: static int, T](s: var StorageN1[N, T]) =
   for i in 0 .. N:
     s.data[i].reset()
 
-proc `[]`*[N: static int, T](s: StorageN1[N, T], idx: PhysicalSlotN1[N]): T {.inline.} =
+proc `[]`*[N: static int, T](
+    s: StorageN1[N, T], idx: PhysicalSlotN1[N]
+): T {.inline, notATransition.} =
   s.data[idx.slotValue]
 
 proc `[]`*[N: static int, T](
     s: var StorageN1[N, T], idx: PhysicalSlotN1[N]
-): var T {.inline.} =
+): var T {.inline, notATransition.} =
   s.data[idx.slotValue]
 
 proc `[]=`*[N: static int, T](
     s: var StorageN1[N, T], idx: PhysicalSlotN1[N], val: T
-) {.inline.} =
+) {.inline, notATransition.} =
   s.data[idx.slotValue] = val

--- a/src/lockfreequeues/typestates/unbounded_mpmc_pop.nim
+++ b/src/lockfreequeues/typestates/unbounded_mpmc_pop.nim
@@ -99,7 +99,7 @@ proc startPop*[T; S, MT: static int](
 # Extract Pinned state from terminal states
 proc extractPinned*[T; S, MT: static int](
     complete: sink MPMCPopComplete[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](handle: complete.pinnedHandle, epoch: complete.pinnedEpoch)
@@ -107,7 +107,7 @@ proc extractPinned*[T; S, MT: static int](
 
 proc extractPinned*[T; S, MT: static int](
     empty: sink MPMCPopEmpty[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](handle: empty.pinnedHandle, epoch: empty.pinnedEpoch)
@@ -115,7 +115,7 @@ proc extractPinned*[T; S, MT: static int](
 
 proc extractPinned*[T; S, MT: static int](
     uncommitted: sink MPMCPopSlotUncommitted[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](
@@ -254,6 +254,8 @@ proc advanceSegment*[T; S, MT: static int](
     )
 
 # Get value from completed pop
-proc getValue*[T; S, MT: static int](complete: MPMCPopComplete[T, S, MT]): T =
+proc getValue*[T; S, MT: static int](
+    complete: MPMCPopComplete[T, S, MT]
+): T {.notATransition.} =
   ## Extract the popped value.
   complete.value

--- a/src/lockfreequeues/typestates/unbounded_mpmc_push.nim
+++ b/src/lockfreequeues/typestates/unbounded_mpmc_push.nim
@@ -99,7 +99,7 @@ proc startPush*[T; S, MT: static int](
 # Extract Pinned state from MPMCPushComplete for unpinning
 proc extractPinned*[T; S, MT: static int](
     complete: sink MPMCPushComplete[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](handle: complete.pinnedHandle, epoch: complete.pinnedEpoch)
@@ -208,7 +208,7 @@ proc allocateNewSegment*[T; S, MT: static int](
 # Helper that returns allocation status (for callers who need to know if they should free newSegment)
 proc tryAllocateNewSegment*[T; S, MT: static int](
     full: sink MPMCPushSegmentFull[T, S, MT], newSegment: ptr MPMCSegment[S, T]
-): tuple[ready: MPMCPushReady[T, S, MT], allocated: bool] =
+): tuple[ready: MPMCPushReady[T, S, MT], allocated: bool] {.notATransition.} =
   ## Try to link new segment using CAS.
   ## Returns (ready state, true if we allocated, false if someone else did).
   ## This is a non-transition helper that wraps allocateNewSegment.

--- a/src/lockfreequeues/typestates/unbounded_mpsc_pop.nim
+++ b/src/lockfreequeues/typestates/unbounded_mpsc_pop.nim
@@ -93,7 +93,7 @@ proc startPop*[T; S, MT: static int](
 # Extract Pinned state from terminal states
 proc extractPinned*[T; S, MT: static int](
     complete: sink MPSCPopComplete[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](handle: complete.pinnedHandle, epoch: complete.pinnedEpoch)
@@ -101,7 +101,7 @@ proc extractPinned*[T; S, MT: static int](
 
 proc extractPinned*[T; S, MT: static int](
     empty: sink MPSCPopEmpty[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](handle: empty.pinnedHandle, epoch: empty.pinnedEpoch)
@@ -109,7 +109,7 @@ proc extractPinned*[T; S, MT: static int](
 
 proc extractPinned*[T; S, MT: static int](
     uncommitted: sink MPSCPopSlotUncommitted[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](
@@ -222,6 +222,8 @@ proc advanceSegment*[T; S, MT: static int](
     )
 
 # Get value from completed pop
-proc getValue*[T; S, MT: static int](complete: MPSCPopComplete[T, S, MT]): T =
+proc getValue*[T; S, MT: static int](
+    complete: MPSCPopComplete[T, S, MT]
+): T {.notATransition.} =
   ## Extract the popped value.
   complete.value

--- a/src/lockfreequeues/typestates/unbounded_mpsc_push.nim
+++ b/src/lockfreequeues/typestates/unbounded_mpsc_push.nim
@@ -99,7 +99,7 @@ proc startPush*[T; S, MT: static int](
 # Extract Pinned state from MPSCPushComplete for unpinning
 proc extractPinned*[T; S, MT: static int](
     complete: sink MPSCPushComplete[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](handle: complete.pinnedHandle, epoch: complete.pinnedEpoch)
@@ -208,7 +208,7 @@ proc allocateNewSegment*[T; S, MT: static int](
 # Helper that returns allocation status (for callers who need to know if they should free newSegment)
 proc tryAllocateNewSegment*[T; S, MT: static int](
     full: sink MPSCPushSegmentFull[T, S, MT], newSegment: ptr MPSCSegment[S, T]
-): tuple[ready: MPSCPushReady[T, S, MT], allocated: bool] =
+): tuple[ready: MPSCPushReady[T, S, MT], allocated: bool] {.notATransition.} =
   ## Try to link new segment using CAS.
   ## Returns (ready state, true if we allocated, false if someone else did).
   ## This is a non-transition helper that wraps allocateNewSegment.

--- a/src/lockfreequeues/typestates/unbounded_spmc_pop.nim
+++ b/src/lockfreequeues/typestates/unbounded_spmc_pop.nim
@@ -100,7 +100,7 @@ proc startPop*[T; S, MT: static int](
 # Extract Pinned state from terminal states
 proc extractPinned*[T; S, MT: static int](
     complete: sink SPMCPopComplete[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](handle: complete.pinnedHandle, epoch: complete.pinnedEpoch)
@@ -108,7 +108,7 @@ proc extractPinned*[T; S, MT: static int](
 
 proc extractPinned*[T; S, MT: static int](
     empty: sink SPMCPopEmpty[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](handle: empty.pinnedHandle, epoch: empty.pinnedEpoch)
@@ -226,6 +226,8 @@ proc advanceSegment*[T; S, MT: static int](
     )
 
 # Get value from completed pop
-proc getValue*[T; S, MT: static int](complete: SPMCPopComplete[T, S, MT]): T =
+proc getValue*[T; S, MT: static int](
+    complete: SPMCPopComplete[T, S, MT]
+): T {.notATransition.} =
   ## Extract the popped value.
   complete.value

--- a/src/lockfreequeues/typestates/unbounded_spmc_push.nim
+++ b/src/lockfreequeues/typestates/unbounded_spmc_push.nim
@@ -89,7 +89,7 @@ proc startPush*[T; S, MT: static int](
 # Extract Pinned state from SPMCPushComplete for unpinning
 proc extractPinned*[T; S, MT: static int](
     complete: sink SPMCPushComplete[T, S, MT]
-): Pinned[MT] =
+): Pinned[MT] {.notATransition.} =
   ## Extract DEBRA's Pinned state for unpinning.
   Pinned[MT](
     EpochGuardContext[MT](handle: complete.pinnedHandle, epoch: complete.pinnedEpoch)

--- a/src/lockfreequeues/typestates/unbounded_spsc_pop.nim
+++ b/src/lockfreequeues/typestates/unbounded_spsc_pop.nim
@@ -128,6 +128,8 @@ proc readItem*[T; S: static int](
   )
 
 # Get value from completed pop
-proc getValue*[T; S: static int](complete: USPSCPopComplete[T, S]): T =
+proc getValue*[T; S: static int](
+    complete: USPSCPopComplete[T, S]
+): T {.notATransition.} =
   ## Extract the popped value.
   complete.value


### PR DESCRIPTION
Fixes an invalid CAS failure memory ordering that aborts the build/test suite on `devel`, and adds Nim `devel` to the CI matrix (carried over from the `test-nim-devel` branch).

## The bug

Five `compareExchangeWeak` calls used `success=moRelease` with `failure=moAcquire`. The atomics memory model forbids this: a release-only success has no load-acquire component for the failure path. nim-debra's `main` rejects the combination at **compile time** (`validCasFailureOrder` in `atomics.nim`), so the build fails before any test runs — on stable Nim too, not just `devel`. The nim-devel matrix addition merely made the pre-existing breakage visible.

Fixed sites (all changed to `moRelease, moRelaxed`):
- `typestates/cas.nim` — generic `executeCAS` helper
- `mupmuc.nim` (×2), `mupsic.nim`, `sipmuc.nim` — producer/consumer thread-id slot registration

`moRelaxed` is the correct failure ordering at every site: on CAS failure the observed value is discarded (the loop just tries the next slot / the caller re-observes), so acquire-on-failure buys nothing. The `moRelease` success is retained and pairs with the existing `load(moAcquire)` lookups. This matches the release/relaxed convention used everywhere else in the codebase.

This is not a nim-debra change — nim-debra correctly rejected the invalid ordering.

## Verification

Against nim-debra `main` (0.10.0, the version CI uses): **210/210** tests pass under `c`, `cpp`, `--mm:arc`, and `--mm:refc`. A negative control (restoring the old `moAcquire` failure ordering) fails to compile with the exact assertion, confirming the guard is live.

## CI

Adds Nim `devel` to the test matrix so future memory-model regressions surface against the development compiler as well as stable.
