### PR TITLE
release: v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-06-24
+
 ### BREAKING
 
 - `CASAttempt` typestate restructured into a proper typestate union. `CASPending` now transitions to `CASSucceeded | CASFailed` (aliased as `CASResult`) via `executeCAS`, replacing the previous single-state design with `assumeSuccess` / `assumeFailure` escape hatches. The `assumeSuccess` and `assumeFailure` procs have been removed. Callers that drove `CASAttempt` outside the bundled MPMC machinery must migrate to the union return form. These helpers were only consumed by `tests/t_cas.nim`; the bundled MPMC machinery calls `compareExchangeWeak` directly and was unaffected. No public lock-free queue API is affected.
@@ -488,10 +490,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added (typestates 0.7 uplift)
 
 - CI: `typestates verify -W --format=github src/` step in `build.yml` to gate the typestate model against drift.
+- CI: Nim `devel` added to the `build.yml` test matrix alongside `stable`, so memory-model and atomics-ordering regressions surface against the development compiler.
 
 ### Fixed (typestates 0.7 uplift)
 
 - 22 read-only typestate accessors across `src/lockfreequeues/typestates/` now carry `{.notATransition.}`. typestates' verifier flagged these once `typestates verify -W` was wired into CI; the procs are pure data extraction and were never transitions.
+- CAS failure memory ordering corrected to `moRelaxed` in the `executeCAS` typestate helper (`typestates/cas.nim`) and in the producer/consumer thread-id registration of the bounded `mupmuc` / `mupsic` / `sipmuc` queues. The prior `moRelease` success / `moAcquire` failure combination is rejected by DEBRA's atomics ordering validation and fails to build against current nim-debra and Nim `devel`. Behaviour is unchanged: the value observed on a failed CAS is discarded, so the failure ordering carries no acquire obligation.
+- Remaining accessor and operation-finalizer procs across `src/lockfreequeues/typestates/` marked `{.notATransition.}` so `typestates verify -W` passes with zero findings under `strictTransitions`; `import typestates` added to the five accessor-only modules that needed the pragma template in scope.
 
 ## [4.1.0] - 2026-05-01
 

--- a/lockfreequeues.nimble
+++ b/lockfreequeues.nimble
@@ -1,7 +1,7 @@
 import os
 
 # Package
-version        = "4.1.0"
+version        = "4.2.0"
 author         = "Elijah Shaw-Rutschman"
 description    = "Lock-free queue implementations for Nim."
 license        = "MIT"


### PR DESCRIPTION
Cuts the **v4.2.0** release.

- Stamps the accumulated `[Unreleased]` changelog as `## [4.2.0] - 2026-06-24` and opens a fresh `[Unreleased]`.
- Bumps `lockfreequeues.nimble` to `4.2.0`.

Records this cycle's additions on top of the bench/docs/typestates work already on `devel`:
- CAS failure memory ordering corrected to `moRelaxed` in `executeCAS` and the bounded `mupmuc`/`mupsic`/`sipmuc` thread-id registration (the prior `moRelease`/`moAcquire` combination fails to build against current nim-debra / Nim `devel`; behaviour unchanged).
- Remaining typestate accessor/finalizer procs marked `{.notATransition.}` so `typestates verify -W` passes under `strictTransitions`.
- Nim `devel` added to the CI test matrix.

On merge to `devel`, `release.yml` parses the nimble version, tags `v4.2.0`, and creates the GitHub Release.

Note: the `[4.2.0]` changelog section carries duplicate category headers and a few mis-categorized entries accumulated across the cycle's PRs (pre-existing, not introduced here). Consolidating it is a reasonable follow-up but was left out of this release-stamp to avoid risk of dropping entries.
