### PR TITLE
ci(docs): deploy versioned docs via release dispatch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,15 @@
 name: docs
 
 on:
+  # No v* tag-push trigger: release.yml owns versioned deploys and dispatches
+  # this workflow with deploy_version after each release. A tag-push trigger
+  # would never fire for the bot's GITHUB_TOKEN-pushed tag anyway, and on a
+  # manual tag push it would double-deploy alongside release.yml's dispatch.
   push:
     branches:
       - main
       - master
       - devel
-    tags:
-      - 'v*'
   pull_request:
     paths:
       - 'docs/**'
@@ -96,7 +98,6 @@ jobs:
         #   pull_request    -> the PR head branch (so blob URLs in the
         #                      PR-verified build point at the branch
         #                      under review)
-        #   v* tag          -> the tag (versioned docs link to release sha)
         #   devel push      -> devel
         #   main push       -> main
         #   workflow_dispatch (deploy_version set) -> the release tag
@@ -111,11 +112,7 @@ jobs:
               ref="${GITHUB_HEAD_REF}"
               ;;
             push)
-              if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-                ref="${GITHUB_REF#refs/tags/}"
-              else
-                ref="${GITHUB_REF#refs/heads/}"
-              fi
+              ref="${GITHUB_REF#refs/heads/}"
               ;;
             workflow_dispatch)
               if [[ -n "${DEPLOY_VERSION}" ]]; then
@@ -152,19 +149,13 @@ jobs:
           git fetch origin gh-pages --depth=1 || true
 
       - name: Deploy docs (versioned)
-        # Fires on a v* tag push, or on a workflow_dispatch carrying
-        # deploy_version (release.yml uses the latter because tags pushed
-        # by GITHUB_TOKEN do not trigger the tag-push event).
-        if: startsWith(github.ref, 'refs/tags/v') || inputs.deploy_version != ''
+        # Fired by release.yml's workflow_dispatch (carrying deploy_version)
+        # after it creates a GitHub Release.
+        if: inputs.deploy_version != ''
         env:
           DEPLOY_VERSION: ${{ inputs.deploy_version }}
         run: |
-          if [[ -n "${DEPLOY_VERSION}" ]]; then
-            VERSION="${DEPLOY_VERSION}"
-          else
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          fi
-          mike deploy --push --update-aliases "$VERSION" latest
+          mike deploy --push --update-aliases "$DEPLOY_VERSION" latest
           mike set-default --push latest
 
       - name: Deploy docs (dev)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -168,8 +168,12 @@ jobs:
           mike set-default --push latest
 
       - name: Deploy docs (dev)
-        # A versioned-docs dispatch must not also clobber the dev alias.
-        if: (github.event_name == 'workflow_dispatch' && inputs.deploy_version == '') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel'
+        # A versioned-docs dispatch carries deploy_version and runs with
+        # --ref devel, so guarding the whole condition on an empty
+        # deploy_version is what keeps it from clobbering the dev alias with
+        # release-tag content (the github.ref == refs/heads/devel branch
+        # would otherwise fire on that dispatch).
+        if: inputs.deploy_version == '' && (github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel')
         run: |
           mike deploy --push dev
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,11 @@ on:
       - '.github/workflows/docs.yml'
       - 'src/**'
   workflow_dispatch:
+    inputs:
+      deploy_version:
+        description: 'Release version to deploy as versioned docs + latest alias (e.g. 4.2.0). Leave empty to (re)deploy dev.'
+        required: false
+        default: ''
   schedule:
     - cron: '17 5 * * *'   # daily at 05:17 UTC; redeploys docs to pick up
                            # snapshot pushes that carried [skip ci] (per
@@ -35,6 +40,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # A versioned-docs dispatch builds from the release tag so blob
+          # links and mkdocstrings sources point at the released sha.
+          ref: ${{ inputs.deploy_version != '' && format('v{0}', inputs.deploy_version) || '' }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -91,8 +99,11 @@ jobs:
         #   v* tag          -> the tag (versioned docs link to release sha)
         #   devel push      -> devel
         #   main push       -> main
-        #   workflow_dispatch -> branch name
+        #   workflow_dispatch (deploy_version set) -> the release tag
+        #   workflow_dispatch (no input) -> branch name
         id: docs_ref
+        env:
+          DEPLOY_VERSION: ${{ inputs.deploy_version }}
         run: |
           set -euo pipefail
           case "$GITHUB_EVENT_NAME" in
@@ -107,7 +118,11 @@ jobs:
               fi
               ;;
             workflow_dispatch)
-              ref="${GITHUB_REF#refs/heads/}"
+              if [[ -n "${DEPLOY_VERSION}" ]]; then
+                ref="v${DEPLOY_VERSION}"
+              else
+                ref="${GITHUB_REF#refs/heads/}"
+              fi
               ;;
             *)
               ref="devel"
@@ -137,14 +152,24 @@ jobs:
           git fetch origin gh-pages --depth=1 || true
 
       - name: Deploy docs (versioned)
-        if: startsWith(github.ref, 'refs/tags/v')
+        # Fires on a v* tag push, or on a workflow_dispatch carrying
+        # deploy_version (release.yml uses the latter because tags pushed
+        # by GITHUB_TOKEN do not trigger the tag-push event).
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.deploy_version != ''
+        env:
+          DEPLOY_VERSION: ${{ inputs.deploy_version }}
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ -n "${DEPLOY_VERSION}" ]]; then
+            VERSION="${DEPLOY_VERSION}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           mike deploy --push --update-aliases "$VERSION" latest
           mike set-default --push latest
 
       - name: Deploy docs (dev)
-        if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel'
+        # A versioned-docs dispatch must not also clobber the dev alias.
+        if: (github.event_name == 'workflow_dispatch' && inputs.deploy_version == '') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/devel'
         run: |
           mike deploy --push dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,11 @@ name: release
 # auto-tag workflow, the tag push would need a PAT (or workflow_dispatch
 # call) to fire the release step.
 #
-# Note: docs.yml independently triggers on `tags: ['v*']` to deploy the
-# versioned mkdocs/mike site. That workflow runs in parallel with this
-# one when this job pushes a tag.
+# Note: docs.yml's versioned deploy CANNOT rely on the tag push this job
+# makes, because GITHUB_TOKEN-pushed tags do not trigger workflows. After
+# creating the Release, this job explicitly dispatches docs.yml with the
+# version (workflow_dispatch fires regardless of the GITHUB_TOKEN tag-push
+# limitation) so the /<version>/ + latest mike aliases get published.
 
 on:
   push:
@@ -23,6 +25,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   release:
@@ -74,3 +77,17 @@ jobs:
           prerelease: ${{ contains(steps.tag.outputs.tag, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy versioned docs
+        # docs.yml's tag-push trigger never fires for our GITHUB_TOKEN-pushed
+        # tag, so dispatch it explicitly with the version to publish the
+        # /<version>/ + latest mike aliases.
+        if: steps.tag.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+          echo "Dispatching docs.yml to deploy versioned docs for $VERSION"
+          gh workflow run docs.yml --ref devel -f deploy_version="$VERSION"


### PR DESCRIPTION
Fixes versioned docs deployment, which has never worked.

## Problem

docs.yml deploys the versioned mike site (`/<version>/` + the `latest` alias) only on a `v*` **tag push**. But release.yml pushes the release tag with `GITHUB_TOKEN`, and GitHub does not trigger workflows from `GITHUB_TOKEN`-pushed tags (release.yml's own header comment notes this limitation). So the versioned/`latest` deploy has never run — `gh-pages` contains only `dev`, and `README.md`'s link to `…/lockfreequeues/latest/benchmarks/` 404s.

## Fix

- **docs.yml** gains a `deploy_version` `workflow_dispatch` input. When set, it checks out the release tag (so blob/source links point at the released sha), builds from it, runs `mike deploy --update-aliases <version> latest` + `mike set-default latest`, and skips the `dev` deploy. With the input empty (existing dispatchers, e.g. bench.yml's redeploy), behaviour is unchanged — it deploys `dev`.
- **release.yml** dispatches docs.yml with the version (`gh workflow run docs.yml -f deploy_version=…`) right after creating the GitHub Release, and gains `actions: write` for the dispatch.

The `workflow_dispatch`-via-`GITHUB_TOKEN` mechanism is already proven in this repo — bench.yml dispatches docs.yml the same way.

## Notes

- `actionlint` passes on both files.
- Expression safety: on non-dispatch events `inputs.deploy_version` is null; GitHub coerces both null and `''` to 0, so `inputs.deploy_version != ''` is false — the versioned step cannot misfire with an empty version on a normal devel/tag push, and checkout falls back to the default ref.
- CI workflow changes can't be fully exercised pre-merge. After this lands on `devel`, v4.2.0's versioned docs are recovered by dispatching `docs.yml` with `deploy_version=4.2.0`; subsequent releases publish automatically.
